### PR TITLE
Add stdin FD redirection and harden stdio handling

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -51,8 +51,7 @@ struct arapuca_ArapucaProfile *arapuca_profile_new(void);
  * # Safety
  * `profile` and `path` must be valid pointers.
  */
-int32_t arapuca_profile_add_read_path(struct arapuca_ArapucaProfile *profile,
-                                        const char *path);
+int32_t arapuca_profile_add_read_path(struct arapuca_ArapucaProfile *profile, const char *path);
 
 /**
  * Add a read-write path to the profile. Returns 0 on success, -1 on error.
@@ -60,8 +59,7 @@ int32_t arapuca_profile_add_read_path(struct arapuca_ArapucaProfile *profile,
  * # Safety
  * `profile` and `path` must be valid pointers.
  */
-int32_t arapuca_profile_add_write_path(struct arapuca_ArapucaProfile *profile,
-                                         const char *path);
+int32_t arapuca_profile_add_write_path(struct arapuca_ArapucaProfile *profile, const char *path);
 
 /**
  * Set memory limit in MB.
@@ -93,8 +91,7 @@ void arapuca_profile_set_max_pids(struct arapuca_ArapucaProfile *profile, uint32
  * # Safety
  * `profile` must be a valid pointer.
  */
-void arapuca_profile_set_max_file_size_mb(struct arapuca_ArapucaProfile *profile,
-                                            uint64_t mb);
+void arapuca_profile_set_max_file_size_mb(struct arapuca_ArapucaProfile *profile, uint64_t mb);
 
 /**
  * Enable/disable network namespace isolation.
@@ -147,7 +144,7 @@ struct arapuca_ArapucaConfig *arapuca_config_new(void);
  * Both pointers must be valid.
  */
 int32_t arapuca_config_set_profile(struct arapuca_ArapucaConfig *cfg,
-                                     const struct arapuca_ArapucaProfile *profile);
+                                   const struct arapuca_ArapucaProfile *profile);
 
 /**
  * Set the task ID on a config.
@@ -180,6 +177,14 @@ int32_t arapuca_config_set_socket_dir(struct arapuca_ArapucaConfig *cfg, const c
  * Both pointers must be valid.
  */
 int32_t arapuca_config_set_work_dir(struct arapuca_ArapucaConfig *cfg, const char *dir);
+
+/**
+ * Set stdin FD on a config.
+ *
+ * # Safety
+ * `cfg` must be a valid pointer.
+ */
+void arapuca_config_set_stdin_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
 
 /**
  * Set stdout FD on a config.
@@ -223,12 +228,12 @@ void arapuca_config_free(struct arapuca_ArapucaConfig *cfg);
  * `extra_fds` must have `extra_fds_count` entries (or be NULL if 0).
  */
 struct arapuca_ArapucaProcess *arapuca_launch(struct arapuca_ArapucaSandbox *sb,
-                                                    const struct arapuca_ArapucaConfig *cfg,
-                                                    const char *cmd,
-                                                    const char *const *args,
-                                                    uintptr_t args_count,
-                                                    const int32_t *extra_fds,
-                                                    uintptr_t extra_fds_count);
+                                              const struct arapuca_ArapucaConfig *cfg,
+                                              const char *cmd,
+                                              const char *const *args,
+                                              uintptr_t args_count,
+                                              const int32_t *extra_fds,
+                                              uintptr_t extra_fds_count);
 
 /**
  * Get the PID of a sandboxed process.
@@ -261,7 +266,7 @@ int32_t arapuca_process_wait(struct arapuca_ArapucaProcess *proc);
  * Both pointers must be valid.
  */
 int32_t arapuca_process_resource_stats(const struct arapuca_ArapucaProcess *proc,
-                                         struct arapuca_ArapucaResourceUsage *out);
+                                       struct arapuca_ArapucaResourceUsage *out);
 
 /**
  * Read OOM kill count from the process's cgroup.

--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -179,28 +179,28 @@ int32_t arapuca_config_set_socket_dir(struct arapuca_ArapucaConfig *cfg, const c
 int32_t arapuca_config_set_work_dir(struct arapuca_ArapucaConfig *cfg, const char *dir);
 
 /**
- * Set stdin FD on a config.
+ * Set stdin FD on a config. Returns 0 on success, -1 on error.
  *
  * # Safety
  * `cfg` must be a valid pointer.
  */
-void arapuca_config_set_stdin_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
+int32_t arapuca_config_set_stdin_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
 
 /**
- * Set stdout FD on a config.
+ * Set stdout FD on a config. Returns 0 on success, -1 on error.
  *
  * # Safety
  * `cfg` must be a valid pointer.
  */
-void arapuca_config_set_stdout_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
+int32_t arapuca_config_set_stdout_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
 
 /**
- * Set stderr FD on a config.
+ * Set stderr FD on a config. Returns 0 on success, -1 on error.
  *
  * # Safety
  * `cfg` must be a valid pointer.
  */
-void arapuca_config_set_stderr_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
+int32_t arapuca_config_set_stderr_fd(struct arapuca_ArapucaConfig *cfg, int32_t fd);
 
 /**
  * Set network proxy socket path on a config.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -361,43 +361,53 @@ pub unsafe extern "C" fn arapuca_config_set_work_dir(
     unsafe { set_config_string(cfg, dir, |c, s| c.work_dir = Some(PathBuf::from(s))) }
 }
 
-/// Set stdin FD on a config.
+/// Helper to set an FD field on a config with validation.
 ///
-/// # Safety
-/// `cfg` must be a valid pointer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn arapuca_config_set_stdin_fd(cfg: *mut ArapucaConfig, fd: i32) {
-    if let Some(cfg) = unsafe { cfg.as_mut() } {
-        if let Some(inner) = cfg.inner.as_mut() {
-            inner.stdin = Some(fd);
-        }
+/// FDs 0, 1, 2 are valid — `F_DUPFD_CLOEXEC` creates a new FD without
+/// disturbing the parent's original stdio descriptors.
+fn set_config_fd(cfg: *mut ArapucaConfig, fd: i32, setter: impl FnOnce(&mut Config, i32)) -> i32 {
+    clear_error();
+    let Some(cfg) = (unsafe { cfg.as_mut() }) else {
+        set_error("null config pointer");
+        return -1;
+    };
+    let Some(inner) = cfg.inner.as_mut() else {
+        set_error("config already freed");
+        return -1;
+    };
+    if fd < 0 {
+        set_error("invalid fd: must be >= 0");
+        return -1;
     }
+    setter(inner, fd);
+    0
 }
 
-/// Set stdout FD on a config.
+/// Set stdin FD on a config. Returns 0 on success, -1 on error.
 ///
 /// # Safety
 /// `cfg` must be a valid pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn arapuca_config_set_stdout_fd(cfg: *mut ArapucaConfig, fd: i32) {
-    if let Some(cfg) = unsafe { cfg.as_mut() } {
-        if let Some(inner) = cfg.inner.as_mut() {
-            inner.stdout = Some(fd);
-        }
-    }
+pub unsafe extern "C" fn arapuca_config_set_stdin_fd(cfg: *mut ArapucaConfig, fd: i32) -> i32 {
+    set_config_fd(cfg, fd, |c, fd| c.stdin = Some(fd))
 }
 
-/// Set stderr FD on a config.
+/// Set stdout FD on a config. Returns 0 on success, -1 on error.
 ///
 /// # Safety
 /// `cfg` must be a valid pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn arapuca_config_set_stderr_fd(cfg: *mut ArapucaConfig, fd: i32) {
-    if let Some(cfg) = unsafe { cfg.as_mut() } {
-        if let Some(inner) = cfg.inner.as_mut() {
-            inner.stderr = Some(fd);
-        }
-    }
+pub unsafe extern "C" fn arapuca_config_set_stdout_fd(cfg: *mut ArapucaConfig, fd: i32) -> i32 {
+    set_config_fd(cfg, fd, |c, fd| c.stdout = Some(fd))
+}
+
+/// Set stderr FD on a config. Returns 0 on success, -1 on error.
+///
+/// # Safety
+/// `cfg` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_config_set_stderr_fd(cfg: *mut ArapucaConfig, fd: i32) -> i32 {
+    set_config_fd(cfg, fd, |c, fd| c.stderr = Some(fd))
 }
 
 /// Set network proxy socket path on a config.
@@ -939,9 +949,14 @@ mod tests {
             assert_eq!(arapuca_config_set_socket_dir(cfg, dir.as_ptr()), 0);
             assert_eq!(arapuca_config_set_work_dir(cfg, dir.as_ptr()), 0);
             assert_eq!(arapuca_config_set_profile(cfg, profile), 0);
-            arapuca_config_set_stdin_fd(cfg, 0);
-            arapuca_config_set_stdout_fd(cfg, 1);
-            arapuca_config_set_stderr_fd(cfg, 2);
+            assert_eq!(arapuca_config_set_stdin_fd(cfg, 0), 0);
+            assert_eq!(arapuca_config_set_stdout_fd(cfg, 1), 0);
+            assert_eq!(arapuca_config_set_stderr_fd(cfg, 2), 0);
+
+            // Negative FDs are rejected.
+            assert_eq!(arapuca_config_set_stdin_fd(cfg, -1), -1);
+            assert_eq!(arapuca_config_set_stdout_fd(cfg, -1), -1);
+            assert_eq!(arapuca_config_set_stderr_fd(cfg, -1), -1);
 
             arapuca_profile_free(profile);
             arapuca_config_free(cfg);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -282,6 +282,7 @@ pub extern "C" fn arapuca_config_new() -> *mut ArapucaConfig {
             task_id: String::new(),
             phase: String::new(),
             work_dir: None,
+            stdin: None,
             stdout: None,
             stderr: None,
             network_proxy_socket: None,
@@ -358,6 +359,19 @@ pub unsafe extern "C" fn arapuca_config_set_work_dir(
     dir: *const c_char,
 ) -> i32 {
     unsafe { set_config_string(cfg, dir, |c, s| c.work_dir = Some(PathBuf::from(s))) }
+}
+
+/// Set stdin FD on a config.
+///
+/// # Safety
+/// `cfg` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_config_set_stdin_fd(cfg: *mut ArapucaConfig, fd: i32) {
+    if let Some(cfg) = unsafe { cfg.as_mut() } {
+        if let Some(inner) = cfg.inner.as_mut() {
+            inner.stdin = Some(fd);
+        }
+    }
 }
 
 /// Set stdout FD on a config.
@@ -925,6 +939,7 @@ mod tests {
             assert_eq!(arapuca_config_set_socket_dir(cfg, dir.as_ptr()), 0);
             assert_eq!(arapuca_config_set_work_dir(cfg, dir.as_ptr()), 0);
             assert_eq!(arapuca_config_set_profile(cfg, profile), 0);
+            arapuca_config_set_stdin_fd(cfg, 0);
             arapuca_config_set_stdout_fd(cfg, 1);
             arapuca_config_set_stderr_fd(cfg, 2);
 

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -13,7 +13,7 @@
 
 mod darwin_profile;
 
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{FromRawFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -291,9 +291,60 @@ impl Sandbox for Darwin {
             command.env(k, v);
         }
 
-        command.stdin(Stdio::inherit());
-        command.stdout(Stdio::inherit());
-        command.stderr(Stdio::inherit());
+        // Set stdin/stdout/stderr. Dup the FD with CLOEXEC so Rust
+        // doesn't take ownership of the caller's FD (from_raw_fd
+        // consumes it) and a concurrent fork can't leak the duped FD.
+        match cfg.stdin {
+            Some(fd) => {
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+                if duped == -1 {
+                    return Err(Error::Process(format!(
+                        "dup stdin fd: {}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                command.stdin(unsafe { Stdio::from_raw_fd(duped) });
+            }
+            None => {
+                command.stdin(Stdio::inherit());
+            }
+        }
+        match cfg.stdout {
+            Some(fd) => {
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+                if duped == -1 {
+                    return Err(Error::Process(format!(
+                        "dup stdout fd: {}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                command.stdout(unsafe { Stdio::from_raw_fd(duped) });
+            }
+            None => {
+                command.stdout(Stdio::inherit());
+            }
+        }
+        match cfg.stderr {
+            Some(fd) => {
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+                if duped == -1 {
+                    return Err(Error::Process(format!(
+                        "dup stderr fd: {}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                command.stderr(unsafe { Stdio::from_raw_fd(duped) });
+            }
+            None => {
+                command.stderr(Stdio::inherit());
+            }
+        }
 
         // Setsid: detach from host's terminal session (same as Linux).
         // SAFETY: setsid is a simple setter with no pointer arguments.

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -291,6 +291,7 @@ impl Sandbox for Darwin {
             command.env(k, v);
         }
 
+        command.stdin(Stdio::inherit());
         command.stdout(Stdio::inherit());
         command.stderr(Stdio::inherit());
 

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -13,7 +13,7 @@
 
 mod darwin_profile;
 
-use std::os::unix::io::{FromRawFd, RawFd};
+use std::os::unix::io::RawFd;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -291,60 +291,10 @@ impl Sandbox for Darwin {
             command.env(k, v);
         }
 
-        // Set stdin/stdout/stderr. Dup the FD with CLOEXEC so Rust
-        // doesn't take ownership of the caller's FD (from_raw_fd
-        // consumes it) and a concurrent fork can't leak the duped FD.
-        match cfg.stdin {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stdin fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stdin(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stdin(Stdio::inherit());
-            }
-        }
-        match cfg.stdout {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stdout fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stdout(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stdout(Stdio::inherit());
-            }
-        }
-        match cfg.stderr {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stderr fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stderr(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stderr(Stdio::inherit());
-            }
-        }
+        // stdin/stdout/stderr redirection.
+        crate::platform::setup_stdio(&mut command, cfg.stdin, "stdin", Command::stdin)?;
+        crate::platform::setup_stdio(&mut command, cfg.stdout, "stdout", Command::stdout)?;
+        crate::platform::setup_stdio(&mut command, cfg.stderr, "stderr", Command::stderr)?;
 
         // Setsid: detach from host's terminal session (same as Linux).
         // SAFETY: setsid is a simple setter with no pointer arguments.

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -13,7 +13,7 @@
 //! Landlock, seccomp, and rlimits are applied by the arapuca wrapper
 //! binary at startup (before exec-ing the agent).
 
-use std::os::unix::io::{FromRawFd, RawFd};
+use std::os::unix::io::RawFd;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -119,60 +119,10 @@ impl Sandbox for Linux {
             command.env(k, v);
         }
 
-        // Set stdin/stdout/stderr. Dup the FD with CLOEXEC so Rust
-        // doesn't take ownership of the caller's FD (from_raw_fd
-        // consumes it) and a concurrent fork can't leak the duped FD.
-        match cfg.stdin {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stdin fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stdin(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stdin(Stdio::inherit());
-            }
-        }
-        match cfg.stdout {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stdout fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stdout(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stdout(Stdio::inherit());
-            }
-        }
-        match cfg.stderr {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stderr fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stderr(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stderr(Stdio::inherit());
-            }
-        }
+        // Set stdin/stdout/stderr redirection.
+        super::setup_stdio(&mut command, cfg.stdin, "stdin", Command::stdin)?;
+        super::setup_stdio(&mut command, cfg.stdout, "stdout", Command::stdout)?;
+        super::setup_stdio(&mut command, cfg.stderr, "stderr", Command::stderr)?;
 
         // Capture extra_fds for the pre_exec closure.
         let fds_to_inherit: Vec<RawFd> = extra_fds.to_vec();

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -119,9 +119,26 @@ impl Sandbox for Linux {
             command.env(k, v);
         }
 
-        // Set stdout/stderr. Dup the FD with CLOEXEC so Rust doesn't
-        // take ownership of the caller's FD (from_raw_fd consumes it)
-        // and a concurrent fork can't leak the duped FD.
+        // Set stdin/stdout/stderr. Dup the FD with CLOEXEC so Rust
+        // doesn't take ownership of the caller's FD (from_raw_fd
+        // consumes it) and a concurrent fork can't leak the duped FD.
+        match cfg.stdin {
+            Some(fd) => {
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+                if duped == -1 {
+                    return Err(Error::Process(format!(
+                        "dup stdin fd: {}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                command.stdin(unsafe { Stdio::from_raw_fd(duped) });
+            }
+            None => {
+                command.stdin(Stdio::inherit());
+            }
+        }
         match cfg.stdout {
             Some(fd) => {
                 // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -119,12 +119,14 @@ impl Sandbox for Linux {
             command.env(k, v);
         }
 
-        // Set stdout/stderr. Dup the FD so Rust doesn't take
-        // ownership of the caller's FD (from_raw_fd consumes it).
+        // Set stdout/stderr. Dup the FD with CLOEXEC so Rust doesn't
+        // take ownership of the caller's FD (from_raw_fd consumes it)
+        // and a concurrent fork can't leak the duped FD.
         match cfg.stdout {
             Some(fd) => {
-                // SAFETY: dup() on a valid fd returns a new fd we own.
-                let duped = unsafe { libc::dup(fd) };
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
                 if duped == -1 {
                     return Err(Error::Process(format!(
                         "dup stdout fd: {}",
@@ -139,7 +141,9 @@ impl Sandbox for Linux {
         }
         match cfg.stderr {
             Some(fd) => {
-                let duped = unsafe { libc::dup(fd) };
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
                 if duped == -1 {
                     return Err(Error::Process(format!(
                         "dup stderr fd: {}",

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,7 +4,8 @@
 //! the available isolation primitives (Landlock, seccomp, cgroups, netns
 //! on Linux; sandbox-exec on macOS; degraded fallback elsewhere).
 
-use std::os::unix::io::RawFd;
+use std::os::unix::io::{FromRawFd, RawFd};
+use std::process::{Command, Stdio};
 
 use crate::{Config, process::Process};
 
@@ -49,6 +50,38 @@ pub trait Sandbox: Send + Sync {
 
     /// Reports whether cgroups v2 resource limits are available.
     fn cgroups_available(&self) -> bool;
+}
+
+/// Duplicate an optional FD with CLOEXEC and wire it to a Command's
+/// stdin, stdout, or stderr. If `fd` is `None`, inherits from parent.
+///
+/// FDs 0, 1, 2 are valid inputs — `F_DUPFD_CLOEXEC` creates a new FD
+/// without disturbing the parent's original.
+pub(crate) fn setup_stdio(
+    command: &mut Command,
+    fd: Option<RawFd>,
+    stream: &str,
+    setter: fn(&mut Command, Stdio) -> &mut Command,
+) -> crate::Result<()> {
+    match fd {
+        Some(fd) => {
+            // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new fd
+            // we own, with CLOEXEC set atomically.
+            let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+            if duped == -1 {
+                return Err(crate::Error::Process(format!(
+                    "dup {stream} fd: {}",
+                    std::io::Error::last_os_error()
+                )));
+            }
+            // SAFETY: duped is a valid fd we own (verified != -1 above).
+            setter(command, unsafe { Stdio::from_raw_fd(duped) });
+        }
+        None => {
+            setter(command, Stdio::inherit());
+        }
+    }
+    Ok(())
 }
 
 /// Create the appropriate sandbox for the current platform.

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -37,8 +37,25 @@ impl Sandbox for Other {
             command.env(k, v);
         }
 
-        // stdout/stderr redirection. Dup with CLOEXEC so Rust doesn't
-        // take caller's FD and concurrent forks can't leak it.
+        // stdin/stdout/stderr redirection. Dup with CLOEXEC so Rust
+        // doesn't take caller's FD and concurrent forks can't leak it.
+        match cfg.stdin {
+            Some(fd) => {
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+                if duped == -1 {
+                    return Err(Error::Process(format!(
+                        "dup stdin fd: {}",
+                        std::io::Error::last_os_error()
+                    )));
+                }
+                command.stdin(unsafe { Stdio::from_raw_fd(duped) });
+            }
+            None => {
+                command.stdin(Stdio::inherit());
+            }
+        }
         match cfg.stdout {
             Some(fd) => {
                 // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -37,10 +37,13 @@ impl Sandbox for Other {
             command.env(k, v);
         }
 
-        // stdout/stderr redirection. Dup so Rust doesn't take caller's FD.
+        // stdout/stderr redirection. Dup with CLOEXEC so Rust doesn't
+        // take caller's FD and concurrent forks can't leak it.
         match cfg.stdout {
             Some(fd) => {
-                let duped = unsafe { libc::dup(fd) };
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
                 if duped == -1 {
                     return Err(Error::Process(format!(
                         "dup stdout fd: {}",
@@ -55,7 +58,9 @@ impl Sandbox for Other {
         }
         match cfg.stderr {
             Some(fd) => {
-                let duped = unsafe { libc::dup(fd) };
+                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
+                // fd we own, with CLOEXEC set atomically.
+                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
                 if duped == -1 {
                     return Err(Error::Process(format!(
                         "dup stderr fd: {}",

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -4,9 +4,9 @@
 //! no seccomp, no cgroups, no network namespace. Suitable for development
 //! and testing only. Production workloads should use Linux.
 
-use std::os::unix::io::{FromRawFd, RawFd};
+use std::os::unix::io::RawFd;
 use std::os::unix::process::CommandExt;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 use crate::platform::Sandbox;
 use crate::{Config, Error, process::Process};
@@ -37,59 +37,10 @@ impl Sandbox for Other {
             command.env(k, v);
         }
 
-        // stdin/stdout/stderr redirection. Dup with CLOEXEC so Rust
-        // doesn't take caller's FD and concurrent forks can't leak it.
-        match cfg.stdin {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stdin fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stdin(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stdin(Stdio::inherit());
-            }
-        }
-        match cfg.stdout {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stdout fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stdout(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stdout(Stdio::inherit());
-            }
-        }
-        match cfg.stderr {
-            Some(fd) => {
-                // SAFETY: F_DUPFD_CLOEXEC on a valid fd returns a new
-                // fd we own, with CLOEXEC set atomically.
-                let duped = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
-                if duped == -1 {
-                    return Err(Error::Process(format!(
-                        "dup stderr fd: {}",
-                        std::io::Error::last_os_error()
-                    )));
-                }
-                command.stderr(unsafe { Stdio::from_raw_fd(duped) });
-            }
-            None => {
-                command.stderr(Stdio::inherit());
-            }
-        }
+        // stdin/stdout/stderr redirection.
+        super::setup_stdio(&mut command, cfg.stdin, "stdin", Command::stdin)?;
+        super::setup_stdio(&mut command, cfg.stdout, "stdout", Command::stdout)?;
+        super::setup_stdio(&mut command, cfg.stderr, "stderr", Command::stderr)?;
 
         // Extra FD inheritance.
         let fds_to_inherit: Vec<RawFd> = extra_fds.to_vec();

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -35,6 +35,8 @@ pub struct Config {
     pub phase: String,
     /// Working directory for the subprocess (None = inherit).
     pub work_dir: Option<PathBuf>,
+    /// Redirect subprocess stdin from this FD (None = inherit).
+    pub stdin: Option<RawFd>,
     /// Redirect subprocess stdout to this FD (None = inherit).
     pub stdout: Option<RawFd>,
     /// Redirect subprocess stderr to this FD (None = inherit).


### PR DESCRIPTION
- Replace `dup()` with `F_DUPFD_CLOEXEC` for stdout/stderr to prevent FD leaks on concurrent fork
- Add `Config.stdin` field and `arapuca_config_set_stdin_fd()` C API, mirroring stdout/stderr
- Wire stdio FD redirection on Darwin (was hardcoded to `Stdio::inherit()`)
- Extract shared `setup_stdio()` helper, eliminating ~116 lines of duplication
- Add `fd >= 0` validation to all stdio FD setters, change return type from `void` to `i32`

Resolves: #1 