### PR TITLE
Add structured audit events for sandbox lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,8 @@ dependencies = [
  "log",
  "nix",
  "seccompiler",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,13 @@ path = "src/bin/arapuca.rs"
 
 [dependencies]
 log = "0.4"
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 tempfile = "3"
 thiserror = "2"
+
+[features]
+serde = ["dep:serde", "dep:serde_json"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ be bypassed from userspace.
 - **Environment hardening** — dangerous variables (`ARAPUCA_*`,
   `LD_*`, `DYLD_*`, `.NET`/`COR_*` prefixes, interpreter injection
   vectors, Windows shell variables) are filtered before exec
+- **Structured audit events** — optional, zero-cost-when-unused event
+  emission via a caller-supplied sink. Covers the full sandbox lifecycle:
+  which layers were applied or skipped, env filtering decisions,
+  filesystem/network/seccomp policy, resource usage, and cleanup status.
+  Enables compliance (SOC 2, FedRAMP AU-3), SIEM integration, and
+  forensic reconstruction of sandbox posture
 
 ## Quick Start
 
@@ -431,6 +437,9 @@ cargo build --release --target x86_64-unknown-linux-musl
 # Run tests
 cargo test
 
+# Build with JSON audit callback support (FFI consumers)
+cargo build --release --features serde
+
 # Lint
 cargo clippy -- -D warnings
 cargo fmt --check
@@ -459,10 +468,11 @@ src/
 ├── rlimit.rs           # POSIX resource limits
 ├── cgroup.rs           # Cgroups v2 manager (Linux)
 ├── netns.rs            # Network namespace probe (Linux)
+├── audit.rs            # Structured audit events, sink trait, context
 ├── env.rs              # Minimal environment, temp dirs, path utils
 ├── diskquota.rs        # Disk usage monitoring
 ├── process.rs          # Sandboxed process lifecycle
-├── ffi.rs              # C ABI exports
+├── ffi.rs              # C ABI exports (+ audit callback behind serde)
 ├── platform/
 │   ├── mod.rs          # Sandbox trait + factory
 │   ├── linux.rs        # Linux sandbox (Landlock + seccomp + cgroups)

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,545 @@
+//! Structured audit events for sandbox lifecycle.
+//!
+//! Provides machine-readable events recording what restrictions were applied,
+//! what was allowed or denied, and what resources were consumed. Events are
+//! emitted via a caller-supplied [`AuditSink`] trait object — the library
+//! performs no I/O or serialization unless the caller opts in.
+
+use std::sync::Arc;
+use std::time::{Instant, SystemTime};
+
+// ─── Timestamp ─────────────────────────────────────────────────────
+
+/// Monotonic timestamp (nanoseconds since sandbox creation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct AuditTimestamp(pub u64);
+
+// ─── Event types ───────────────────────────────────────────────────
+
+/// A single audit event emitted during sandbox lifecycle.
+///
+/// Events within a single sandbox lifecycle are emitted in causal order.
+/// The monotonic [`AuditTimestamp`] provides total ordering.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(tag = "event_type"))]
+pub enum AuditEvent {
+    /// Sandbox creation started. Always the first event.
+    ///
+    /// `wall_clock_epoch_ns` anchors the monotonic timeline to wall-clock
+    /// time for SIEM correlation. The consumer computes absolute time as
+    /// `wall_clock_epoch_ns + timestamp.0`.
+    #[non_exhaustive]
+    SandboxInit {
+        timestamp: AuditTimestamp,
+        wall_clock_epoch_ns: u64,
+        schema_version: u32,
+        task_id: String,
+        phase: String,
+        command: String,
+        arg_count: usize,
+        /// Only populated when [`AuditVerbosity::Verbose`].
+        args: Option<Vec<String>>,
+        principal: Option<String>,
+        correlation_id: Option<String>,
+    },
+
+    /// A sandbox layer was successfully applied.
+    #[non_exhaustive]
+    LayerApplied {
+        timestamp: AuditTimestamp,
+        layer: SandboxLayer,
+        detail: Option<LayerDetail>,
+    },
+
+    /// A sandbox layer was skipped (degraded mode).
+    #[non_exhaustive]
+    LayerSkipped {
+        timestamp: AuditTimestamp,
+        layer: SandboxLayer,
+        reason: SkipReason,
+    },
+
+    /// A sandbox layer failed to apply (fatal).
+    #[non_exhaustive]
+    LayerFailed {
+        timestamp: AuditTimestamp,
+        layer: SandboxLayer,
+        error: String,
+    },
+
+    /// Environment variable filtering outcome.
+    ///
+    /// Key names are logged (the audit consumer already has full visibility
+    /// into the environment). Values are NEVER logged.
+    #[non_exhaustive]
+    EnvPolicy {
+        timestamp: AuditTimestamp,
+        passed_keys: Vec<String>,
+        dropped: Vec<DroppedEnvVar>,
+    },
+
+    /// Filesystem access policy summary.
+    #[non_exhaustive]
+    FilesystemPolicy {
+        timestamp: AuditTimestamp,
+        read_paths: Vec<String>,
+        write_paths: Vec<String>,
+    },
+
+    /// Resource limits applied.
+    #[non_exhaustive]
+    ResourceLimits {
+        timestamp: AuditTimestamp,
+        memory_mb: u64,
+        cpu_pct: u32,
+        max_pids: u32,
+        max_file_size_mb: u64,
+        allow_exec: bool,
+    },
+
+    /// Network policy applied.
+    #[non_exhaustive]
+    NetworkPolicy {
+        timestamp: AuditTimestamp,
+        isolated: bool,
+        proxy_socket: Option<String>,
+    },
+
+    /// Seccomp filter policy summary.
+    #[non_exhaustive]
+    SeccompPolicy {
+        timestamp: AuditTimestamp,
+        tier1_kill_count: usize,
+        tier2_eperm_count: usize,
+        socket_filter: bool,
+        prctl_filter: bool,
+        allow_exec: bool,
+    },
+
+    /// FD inheritance summary.
+    #[non_exhaustive]
+    FdInheritance {
+        timestamp: AuditTimestamp,
+        inherited_fds: Vec<i32>,
+        stdin_redirected: bool,
+        stdout_redirected: bool,
+        stderr_redirected: bool,
+    },
+
+    /// All mandatory sandbox layers applied — the process is about to start.
+    ///
+    /// This is the primary event compliance systems should key on.
+    /// Absence of this event after [`AuditEvent::SandboxInit`] means the
+    /// setup was interrupted.
+    #[non_exhaustive]
+    SandboxReady {
+        timestamp: AuditTimestamp,
+        applied_layers: Vec<SandboxLayer>,
+        skipped_layers: Vec<SandboxLayer>,
+    },
+
+    /// Subprocess launched successfully.
+    #[non_exhaustive]
+    ProcessStarted { timestamp: AuditTimestamp, pid: u32 },
+
+    /// Subprocess exited.
+    ///
+    /// `exit_code`, `signal`, and `oom_kill_count` are influenced by the
+    /// child process (kernel observations, not forgeable).
+    #[non_exhaustive]
+    ProcessExited {
+        timestamp: AuditTimestamp,
+        pid: u32,
+        exit_code: Option<i32>,
+        signal: Option<i32>,
+        oom_kill_count: u32,
+    },
+
+    /// Resource usage at exit (from cgroups).
+    #[non_exhaustive]
+    ResourceUsage {
+        timestamp: AuditTimestamp,
+        memory_current_bytes: i64,
+        memory_peak_bytes: i64,
+        cpu_seconds: f64,
+        pid_count: i64,
+        io_read_bytes: i64,
+        io_write_bytes: i64,
+    },
+
+    /// Sandbox cleanup completed.
+    #[non_exhaustive]
+    SandboxCleanup {
+        timestamp: AuditTimestamp,
+        cgroup_destroyed: bool,
+        tmpdir_removed: bool,
+        dacls_restored: Option<bool>,
+        container_deleted: Option<bool>,
+    },
+}
+
+/// Current schema version. Incremented only for breaking changes.
+pub const SCHEMA_VERSION: u32 = 1;
+
+// ─── Supporting types ──────────────────────────────────────────────
+
+/// Sandbox isolation layers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum SandboxLayer {
+    Landlock,
+    Seccomp,
+    Cgroup,
+    NetworkNamespace,
+    Rlimit,
+    Setsid,
+    Pdeathsig,
+    NoNewPrivs,
+    EnvFilter,
+    FdSanitization,
+    // macOS
+    Seatbelt,
+    MemoryMonitor,
+    ParentWatchdog,
+    // Windows
+    AppContainer,
+    JobObject,
+    RestrictedToken,
+    IntegrityLevel,
+    MitigationPolicy,
+    DaclGrant,
+}
+
+/// Structured detail for a successfully applied layer.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum LayerDetail {
+    Landlock {
+        abi_version: u32,
+        fully_enforced: bool,
+    },
+    Cgroup {
+        path: String,
+    },
+    Other(String),
+}
+
+/// Reason a sandbox layer was skipped.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum SkipReason {
+    NotAvailable,
+    NotConfigured,
+    PlatformUnsupported,
+    ComponentMissing(String),
+    PartialFailure(String),
+}
+
+/// Why an environment variable was dropped during filtering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum DropReason {
+    ArapucaPrefix,
+    LauncherReserved,
+    LdPrefix,
+    DyldPrefix,
+    DotnetPrefix,
+    InterpreterInjection,
+    ShellInjection,
+    WindowsShimInjection,
+}
+
+/// An environment variable that was dropped during filtering.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct DroppedEnvVar {
+    pub key: String,
+    pub reason: DropReason,
+}
+
+/// Controls how much detail audit events include.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum AuditVerbosity {
+    #[default]
+    Standard,
+    Verbose,
+}
+
+// ─── Sink trait ────────────────────────────────────────────────────
+
+/// Receiver for audit events.
+///
+/// # Contract
+///
+/// - **Must not panic.** Panics are caught via `catch_unwind` and the
+///   event is lost, but repeated panics degrade audit coverage.
+/// - **Must not block.** `emit()` runs synchronously on the sandbox
+///   creation thread. For I/O-bound sinks, buffer in memory and flush
+///   asynchronously.
+/// - **Must not call back into arapuca.** Reentrancy may deadlock.
+///
+/// Implementations using `Mutex` should handle poisoning gracefully
+/// (e.g., `lock().unwrap_or_else(|e| e.into_inner())`).
+pub trait AuditSink: Send + Sync {
+    fn emit(&self, event: AuditEvent);
+
+    /// If true, audit failure (emit panic) aborts the sandbox launch.
+    ///
+    /// Default: false (best-effort audit). A mandatory failure during
+    /// cleanup may leave resources behind — the caller is responsible
+    /// for handling the returned error.
+    fn is_mandatory(&self) -> bool {
+        false
+    }
+}
+
+// ─── AuditContext ──────────────────────────────────────────────────
+
+/// Internal helper that centralizes timestamp computation and
+/// panic-safe event emission.
+#[allow(dead_code)]
+pub(crate) struct AuditContext {
+    sink: Arc<dyn AuditSink>,
+    epoch: Instant,
+    wall_clock_epoch_ns: u64,
+    verbosity: AuditVerbosity,
+}
+
+#[allow(dead_code)]
+impl AuditContext {
+    pub fn new(sink: Arc<dyn AuditSink>, verbosity: AuditVerbosity) -> Self {
+        let epoch = Instant::now();
+        let wall_clock_epoch_ns = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        Self {
+            sink,
+            epoch,
+            wall_clock_epoch_ns,
+            verbosity,
+        }
+    }
+
+    pub fn timestamp(&self) -> AuditTimestamp {
+        AuditTimestamp(self.epoch.elapsed().as_nanos() as u64)
+    }
+
+    pub fn wall_clock_epoch_ns(&self) -> u64 {
+        self.wall_clock_epoch_ns
+    }
+
+    pub fn verbosity(&self) -> &AuditVerbosity {
+        &self.verbosity
+    }
+
+    /// Emit an event, catching sink panics.
+    ///
+    /// Returns `Err` only when the sink panics AND `is_mandatory()`.
+    // AssertUnwindSafe is safe here: `sink` is an Arc clone (separate
+    // strong ref — the original is untouched on panic) and `event` is
+    // moved into the closure (consumed, not shared).
+    pub fn emit(&self, event: AuditEvent) -> crate::Result<()> {
+        let sink = Arc::clone(&self.sink);
+        let mandatory = self.sink.is_mandatory();
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || sink.emit(event)));
+        if result.is_err() {
+            log::warn!("audit sink panicked, event lost");
+            if mandatory {
+                return Err(crate::Error::Process(
+                    "mandatory audit sink panicked".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for AuditContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuditContext")
+            .field("epoch", &self.epoch)
+            .field("wall_clock_epoch_ns", &self.wall_clock_epoch_ns)
+            .field("verbosity", &self.verbosity)
+            .field("sink", &"<AuditSink>")
+            .finish()
+    }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+/// Strip control characters and bidi overrides from a string before
+/// it enters an audit event, preventing log injection attacks on
+/// downstream consumers.
+#[allow(dead_code)]
+pub(crate) fn sanitize_audit_string(s: &str) -> String {
+    s.chars()
+        .filter(|c| {
+            if c.is_control() && *c != '\n' {
+                return false;
+            }
+            !matches!(
+                *c,
+                '\u{202A}'..='\u{202E}'
+                    | '\u{2066}'..='\u{2069}'
+                    | '\u{200E}'
+                    | '\u{200F}'
+            )
+        })
+        .collect()
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct VecSink(Mutex<Vec<AuditEvent>>);
+
+    impl AuditSink for VecSink {
+        fn emit(&self, event: AuditEvent) {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).push(event);
+        }
+    }
+
+    struct PanickingSink {
+        mandatory: bool,
+    }
+
+    impl AuditSink for PanickingSink {
+        fn emit(&self, _event: AuditEvent) {
+            panic!("deliberate test panic");
+        }
+
+        fn is_mandatory(&self) -> bool {
+            self.mandatory
+        }
+    }
+
+    #[test]
+    fn timestamp_ordering() {
+        let a = AuditTimestamp(100);
+        let b = AuditTimestamp(200);
+        assert!(a < b);
+        assert_eq!(a, AuditTimestamp(100));
+    }
+
+    #[test]
+    fn context_timestamps_increase() {
+        let sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+        let ctx = AuditContext::new(sink, AuditVerbosity::Standard);
+        let t1 = ctx.timestamp();
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let t2 = ctx.timestamp();
+        assert!(t2 > t1);
+    }
+
+    #[test]
+    fn context_wall_clock_is_reasonable() {
+        let sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+        let ctx = AuditContext::new(sink, AuditVerbosity::Standard);
+        assert!(ctx.wall_clock_epoch_ns() > 1_700_000_000_000_000_000);
+    }
+
+    #[test]
+    fn context_emit_delivers_event() {
+        let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+        let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+        let ctx = AuditContext::new(sink, AuditVerbosity::Standard);
+        let event = AuditEvent::ProcessStarted {
+            timestamp: ctx.timestamp(),
+            pid: 42,
+        };
+        ctx.emit(event).unwrap();
+        let events = vec_sink.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn context_catches_sink_panic() {
+        let sink = Arc::new(PanickingSink { mandatory: false });
+        let ctx = AuditContext::new(sink, AuditVerbosity::Standard);
+        let event = AuditEvent::ProcessStarted {
+            timestamp: ctx.timestamp(),
+            pid: 1,
+        };
+        let result = ctx.emit(event);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn context_mandatory_sink_panic_returns_err() {
+        let sink = Arc::new(PanickingSink { mandatory: true });
+        let ctx = AuditContext::new(sink, AuditVerbosity::Standard);
+        let event = AuditEvent::ProcessStarted {
+            timestamp: ctx.timestamp(),
+            pid: 1,
+        };
+        let result = ctx.emit(event);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_strips_control_chars() {
+        assert_eq!(sanitize_audit_string("hello\x00world"), "helloworld");
+        assert_eq!(sanitize_audit_string("tab\there"), "tabhere");
+        assert_eq!(sanitize_audit_string("\x1b[31mred\x1b[0m"), "[31mred[0m");
+    }
+
+    #[test]
+    fn sanitize_preserves_newlines() {
+        assert_eq!(sanitize_audit_string("line1\nline2"), "line1\nline2");
+    }
+
+    #[test]
+    fn sanitize_strips_bidi_overrides() {
+        assert_eq!(sanitize_audit_string("a\u{202E}b\u{202C}c"), "abc");
+        assert_eq!(sanitize_audit_string("x\u{2066}y\u{2069}z"), "xyz");
+    }
+
+    #[test]
+    fn sanitize_preserves_normal_unicode() {
+        assert_eq!(sanitize_audit_string("café ñ 日本語"), "café ñ 日本語");
+    }
+
+    #[test]
+    fn verbosity_default_is_standard() {
+        assert!(matches!(
+            AuditVerbosity::default(),
+            AuditVerbosity::Standard
+        ));
+    }
+
+    #[test]
+    fn drop_reason_variants_exist() {
+        let reasons = [
+            DropReason::ArapucaPrefix,
+            DropReason::LauncherReserved,
+            DropReason::LdPrefix,
+            DropReason::DyldPrefix,
+            DropReason::DotnetPrefix,
+            DropReason::InterpreterInjection,
+            DropReason::ShellInjection,
+            DropReason::WindowsShimInjection,
+        ];
+        assert_eq!(reasons.len(), 8);
+    }
+
+    #[test]
+    fn schema_version_is_one() {
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+}

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -307,7 +307,6 @@ pub trait AuditSink: Send + Sync {
 
 /// Internal helper that centralizes timestamp computation and
 /// panic-safe event emission.
-#[allow(dead_code)]
 pub(crate) struct AuditContext {
     sink: Arc<dyn AuditSink>,
     epoch: Instant,
@@ -315,7 +314,6 @@ pub(crate) struct AuditContext {
     verbosity: AuditVerbosity,
 }
 
-#[allow(dead_code)]
 impl AuditContext {
     pub fn new(sink: Arc<dyn AuditSink>, verbosity: AuditVerbosity) -> Self {
         let epoch = Instant::now();
@@ -382,7 +380,6 @@ impl std::fmt::Debug for AuditContext {
 /// Strip control characters and bidi overrides from a string before
 /// it enters an audit event, preventing log injection attacks on
 /// downstream consumers.
-#[allow(dead_code)]
 pub(crate) fn sanitize_audit_string(s: &str) -> String {
     s.chars()
         .filter(|c| {

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -307,6 +307,7 @@ pub trait AuditSink: Send + Sync {
 
 /// Internal helper that centralizes timestamp computation and
 /// panic-safe event emission.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) struct AuditContext {
     sink: Arc<dyn AuditSink>,
     epoch: Instant,
@@ -314,6 +315,7 @@ pub(crate) struct AuditContext {
     verbosity: AuditVerbosity,
 }
 
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 impl AuditContext {
     pub fn new(sink: Arc<dyn AuditSink>, verbosity: AuditVerbosity) -> Self {
         let epoch = Instant::now();
@@ -380,6 +382,7 @@ impl std::fmt::Debug for AuditContext {
 /// Strip control characters and bidi overrides from a string before
 /// it enters an audit event, preventing log injection attacks on
 /// downstream consumers.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn sanitize_audit_string(s: &str) -> String {
     s.chars()
         .filter(|c| {

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -18,6 +18,13 @@ use std::ffi::CString;
 use std::path::PathBuf;
 
 fn main() {
+    // Audit FD: if set, write JSON status lines as each layer is applied.
+    // The library creates a pipe and passes the write end via this env var.
+    // Closed before execve so the target command cannot write to it.
+    let audit_fd: Option<i32> = std::env::var("ARAPUCA_AUDIT_FD")
+        .ok()
+        .and_then(|s| s.parse().ok());
+
     // Find -- separator.
     let args: Vec<String> = std::env::args().collect();
     let sep_idx = args.iter().position(|a| a == "--");
@@ -59,21 +66,29 @@ fn main() {
         };
 
         if let Err(e) = arapuca::landlock::apply(&profile) {
+            audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
             eprintln!("arapuca: landlock: {e}");
             std::process::exit(1);
         }
+        audit_layer(audit_fd, "Landlock", true, None);
+
         if let Err(e) = arapuca::seccomp::apply() {
+            audit_layer(audit_fd, "Seccomp", false, Some(&e.to_string()));
             eprintln!("arapuca: seccomp: {e}");
             std::process::exit(1);
         }
+        audit_layer(audit_fd, "Seccomp", true, None);
     }
 
     // 3. Resource limits from env vars (Unix only).
     #[cfg(unix)]
     if let Err(e) = arapuca::rlimit::apply_from_env() {
+        audit_layer(audit_fd, "Rlimit", false, Some(&e.to_string()));
         eprintln!("arapuca: rlimit: {e}");
         std::process::exit(1);
     }
+    #[cfg(unix)]
+    audit_layer(audit_fd, "Rlimit", true, None);
 
     // 4. Pdeathsig — kill subprocess if parent dies (Linux only).
     #[cfg(target_os = "linux")]
@@ -87,6 +102,14 @@ fn main() {
                 std::io::Error::last_os_error()
             );
         }
+        audit_layer(audit_fd, "Pdeathsig", true, None);
+    }
+
+    // Close audit FD before exec — the target command must not inherit it.
+    #[cfg(unix)]
+    if let Some(fd) = audit_fd {
+        // SAFETY: fd is a valid file descriptor from ARAPUCA_AUDIT_FD.
+        unsafe { libc::close(fd) };
     }
 
     // Strip ARAPUCA_* env vars so the agent can't inspect its own
@@ -157,6 +180,43 @@ fn env_paths(name: &str) -> Vec<PathBuf> {
         Ok(v) => arapuca::env::parse_paths(&v),
         Err(_) => Vec::new(),
     }
+}
+
+/// Write an audit status line to the audit FD (if set).
+///
+/// Writes newline-delimited JSON. Errors are silently ignored — audit
+/// is observability, not a security gate.
+#[cfg(unix)]
+fn audit_layer(fd: Option<i32>, layer: &str, ok: bool, error: Option<&str>) {
+    let Some(fd) = fd else { return };
+    let status = if ok { "applied" } else { "failed" };
+    let json = if let Some(err) = error {
+        let escaped = json_escape(err);
+        format!(r#"{{"layer":"{layer}","status":"{status}","error":"{escaped}"}}"#)
+    } else {
+        format!(r#"{{"layer":"{layer}","status":"{status}"}}"#)
+    };
+    let line = format!("{json}\n");
+    // SAFETY: fd is a valid descriptor from ARAPUCA_AUDIT_FD, buf/len valid.
+    let _ = unsafe { libc::write(fd, line.as_ptr().cast::<libc::c_void>(), line.len()) };
+}
+
+/// Escape a string for JSON (RFC 8259): backslash, double-quote,
+/// and all control characters below U+0020.
+#[cfg(unix)]
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if c < '\u{0020}' => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 /// Simple PATH lookup for a command name.

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -21,6 +21,7 @@ fn main() {
     // Audit FD: if set, write JSON status lines as each layer is applied.
     // The library creates a pipe and passes the write end via this env var.
     // Closed before execve so the target command cannot write to it.
+    #[cfg(unix)]
     let audit_fd: Option<i32> = std::env::var("ARAPUCA_AUDIT_FD")
         .ok()
         .and_then(|s| s.parse().ok());

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,6 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::audit::{DropReason, DroppedEnvVar};
+
 /// Construct a minimal environment for a sandboxed subprocess.
 ///
 /// Only includes HOME, TMPDIR, PATH, and LANG. This prevents
@@ -21,6 +23,14 @@ pub fn minimal_env(tmp_dir: &Path) -> Vec<(String, String)> {
     ]
 }
 
+/// Result of filtering caller-supplied environment variables.
+pub struct FilterResult {
+    /// Variables that passed the filter.
+    pub passed: Vec<(String, String)>,
+    /// Variables that were dropped, with the reason for each.
+    pub dropped: Vec<DroppedEnvVar>,
+}
+
 /// Filter caller-supplied env vars, dropping dangerous entries.
 ///
 /// Drops vars that could subvert sandbox confinement:
@@ -32,32 +42,63 @@ pub fn minimal_env(tmp_dir: &Path) -> Vec<(String, String)> {
 /// - Interpreter injection: `BASH_ENV`, `ENV`, `PYTHONPATH`,
 ///   `PYTHONSTARTUP`, `NODE_OPTIONS`, `PERL5OPT`, `PERL5LIB`
 /// - `COMSPEC`, `PSModulePath`, `PATHEXT` — Windows shell/exec injection
-pub fn filter_caller_env(env: &[(String, String)]) -> Vec<(String, String)> {
-    const BLOCKED_PREFIXES: &[&str] = &[
-        "ARAPUCA_", "LD_", "DYLD_", "COR_", "CORECLR_", "DOTNET_", "COMPLUS_",
-    ];
-    const BLOCKED_NAMES: &[&str] = &[
-        "AGENT_NETWORK_PROXY",
-        "BASH_ENV",
-        "ENV",
-        "PYTHONPATH",
-        "PYTHONSTARTUP",
-        "NODE_OPTIONS",
-        "PERL5OPT",
-        "PERL5LIB",
-        "COMSPEC",
-        "PSModulePath",
-        "PATHEXT",
-        "__COMPAT_LAYER",
-    ];
+pub fn filter_caller_env(env: &[(String, String)]) -> FilterResult {
+    let mut passed = Vec::new();
+    let mut dropped = Vec::new();
 
-    env.iter()
-        .filter(|(k, _)| {
-            !BLOCKED_PREFIXES.iter().any(|p| k.starts_with(p))
-                && !BLOCKED_NAMES.contains(&k.as_str())
-        })
-        .cloned()
-        .collect()
+    for (k, v) in env {
+        if let Some(reason) = drop_reason(k) {
+            dropped.push(DroppedEnvVar {
+                key: k.clone(),
+                reason,
+            });
+        } else {
+            passed.push((k.clone(), v.clone()));
+        }
+    }
+
+    FilterResult { passed, dropped }
+}
+
+fn drop_reason(key: &str) -> Option<DropReason> {
+    if key.starts_with("ARAPUCA_") {
+        return Some(DropReason::ArapucaPrefix);
+    }
+    if key == "AGENT_NETWORK_PROXY" {
+        return Some(DropReason::LauncherReserved);
+    }
+    if key.starts_with("LD_") {
+        return Some(DropReason::LdPrefix);
+    }
+    if key.starts_with("DYLD_") {
+        return Some(DropReason::DyldPrefix);
+    }
+    if key.starts_with("COR_")
+        || key.starts_with("CORECLR_")
+        || key.starts_with("DOTNET_")
+        || key.starts_with("COMPLUS_")
+    {
+        return Some(DropReason::DotnetPrefix);
+    }
+    if key == "__COMPAT_LAYER" {
+        return Some(DropReason::WindowsShimInjection);
+    }
+    if matches!(
+        key,
+        "BASH_ENV"
+            | "ENV"
+            | "PYTHONPATH"
+            | "PYTHONSTARTUP"
+            | "NODE_OPTIONS"
+            | "PERL5OPT"
+            | "PERL5LIB"
+    ) {
+        return Some(DropReason::InterpreterInjection);
+    }
+    if matches!(key, "COMSPEC" | "PSModulePath" | "PATHEXT") {
+        return Some(DropReason::ShellInjection);
+    }
+    None
 }
 
 /// Create a temporary directory for the sandbox.
@@ -261,7 +302,10 @@ mod tests {
     #[test]
     fn filter_drops_arapuca_prefix() {
         let env = vec![("ARAPUCA_READ_PATHS".into(), "/".into())];
-        assert!(filter_caller_env(&env).is_empty());
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert_eq!(result.dropped.len(), 1);
+        assert_eq!(result.dropped[0].reason, DropReason::ArapucaPrefix);
     }
 
     #[test]
@@ -270,13 +314,23 @@ mod tests {
             ("LD_PRELOAD".into(), "/evil.so".into()),
             ("LD_LIBRARY_PATH".into(), "/tmp".into()),
         ];
-        assert!(filter_caller_env(&env).is_empty());
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert_eq!(result.dropped.len(), 2);
+        assert!(
+            result
+                .dropped
+                .iter()
+                .all(|d| d.reason == DropReason::LdPrefix)
+        );
     }
 
     #[test]
     fn filter_drops_dyld_prefix() {
         let env = vec![("DYLD_INSERT_LIBRARIES".into(), "/evil.dylib".into())];
-        assert!(filter_caller_env(&env).is_empty());
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert_eq!(result.dropped[0].reason, DropReason::DyldPrefix);
     }
 
     #[test]
@@ -294,13 +348,22 @@ mod tests {
             .iter()
             .map(|k| (k.to_string(), "malicious".into()))
             .collect();
-        assert!(filter_caller_env(&env).is_empty());
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert!(
+            result
+                .dropped
+                .iter()
+                .all(|d| d.reason == DropReason::InterpreterInjection)
+        );
     }
 
     #[test]
     fn filter_drops_agent_network_proxy() {
         let env = vec![("AGENT_NETWORK_PROXY".into(), "/tmp/evil.sock".into())];
-        assert!(filter_caller_env(&env).is_empty());
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert_eq!(result.dropped[0].reason, DropReason::LauncherReserved);
     }
 
     #[test]
@@ -309,18 +372,74 @@ mod tests {
             ("MY_TOKEN".into(), "secret123".into()),
             ("JIRA_URL".into(), "https://jira.example.com".into()),
         ];
-        let filtered = filter_caller_env(&env);
-        assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0].0, "MY_TOKEN");
-        assert_eq!(filtered[1].0, "JIRA_URL");
+        let result = filter_caller_env(&env);
+        assert_eq!(result.passed.len(), 2);
+        assert_eq!(result.passed[0].0, "MY_TOKEN");
+        assert_eq!(result.passed[1].0, "JIRA_URL");
+        assert!(result.dropped.is_empty());
     }
 
     #[test]
     fn filter_preserves_value_with_equals() {
         let env = vec![("CONFIG".into(), "key=value=extra".into())];
-        let filtered = filter_caller_env(&env);
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].1, "key=value=extra");
+        let result = filter_caller_env(&env);
+        assert_eq!(result.passed.len(), 1);
+        assert_eq!(result.passed[0].1, "key=value=extra");
+    }
+
+    #[test]
+    fn filter_drops_dotnet_prefix() {
+        let env = vec![
+            ("DOTNET_EnableDiagnostics".into(), "1".into()),
+            ("CORECLR_PROFILER".into(), "evil".into()),
+            ("COR_ENABLE_PROFILING".into(), "1".into()),
+            ("COMPLUS_ForceENC".into(), "1".into()),
+        ];
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert!(
+            result
+                .dropped
+                .iter()
+                .all(|d| d.reason == DropReason::DotnetPrefix)
+        );
+    }
+
+    #[test]
+    fn filter_drops_shell_injection() {
+        let env = vec![
+            ("COMSPEC".into(), "cmd.exe".into()),
+            ("PATHEXT".into(), ".exe".into()),
+        ];
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert!(
+            result
+                .dropped
+                .iter()
+                .all(|d| d.reason == DropReason::ShellInjection)
+        );
+    }
+
+    #[test]
+    fn filter_drops_compat_layer() {
+        let env = vec![("__COMPAT_LAYER".into(), "RunAsInvoker".into())];
+        let result = filter_caller_env(&env);
+        assert!(result.passed.is_empty());
+        assert_eq!(result.dropped[0].reason, DropReason::WindowsShimInjection);
+    }
+
+    #[test]
+    fn filter_mixed_pass_and_drop() {
+        let env = vec![
+            ("SAFE_VAR".into(), "ok".into()),
+            ("LD_PRELOAD".into(), "/evil.so".into()),
+            ("ANOTHER_SAFE".into(), "ok".into()),
+        ];
+        let result = filter_caller_env(&env);
+        assert_eq!(result.passed.len(), 2);
+        assert_eq!(result.dropped.len(), 1);
+        assert_eq!(result.dropped[0].key, "LD_PRELOAD");
     }
 
     #[test]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -293,6 +293,10 @@ pub extern "C" fn arapuca_config_new() -> *mut ArapucaConfig {
             extra_fds: Vec::new(),
             network_proxy_socket: None,
             env: Vec::new(),
+            audit_sink: None,
+            audit_verbosity: crate::audit::AuditVerbosity::Standard,
+            audit_principal: None,
+            audit_correlation_id: None,
         }),
     }))
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -482,6 +482,94 @@ pub unsafe extern "C" fn arapuca_config_add_env(
     0
 }
 
+/// Callback type for receiving audit events as JSON.
+///
+/// # Safety contract
+///
+/// - `event_json` is valid only for the duration of the callback. The
+///   callback must copy the data if it needs to retain it.
+/// - `user_data` must remain valid until `arapuca_process_cleanup()`
+///   returns. Passing stack or freed heap memory is undefined behavior.
+/// - The callback may be invoked from any thread. The callback and
+///   `user_data` must be safe for concurrent access.
+/// - The callback must return normally. `longjmp`, C++ exceptions, and
+///   Go panics in cgo callbacks are undefined behavior.
+/// - The callback must not call any arapuca function (no reentrancy).
+#[cfg(feature = "serde")]
+pub type ArapucaAuditCallback = unsafe extern "C" fn(
+    event_json: *const c_char,
+    event_json_len: usize,
+    user_data: *mut std::ffi::c_void,
+);
+
+#[cfg(feature = "serde")]
+struct FfiAuditSink {
+    callback: ArapucaAuditCallback,
+    user_data: *mut std::ffi::c_void,
+}
+
+// SAFETY: The FFI contract documented above requires user_data to be
+// thread-safe and to outlive the sandbox lifecycle. Non-local control
+// flow from within the callback is documented as UB.
+#[cfg(feature = "serde")]
+unsafe impl Send for FfiAuditSink {}
+#[cfg(feature = "serde")]
+unsafe impl Sync for FfiAuditSink {}
+
+#[cfg(feature = "serde")]
+impl crate::audit::AuditSink for FfiAuditSink {
+    fn emit(&self, event: crate::audit::AuditEvent) {
+        let json = serde_json::to_string(&event)
+            .unwrap_or_else(|_| r#"{"error":"audit event serialization failed"}"#.into());
+        let cstr = match CString::new(json) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let ptr = cstr.as_ptr();
+        let len = cstr.as_bytes().len();
+        unsafe { (self.callback)(ptr, len, self.user_data) };
+    }
+}
+
+/// Set an audit callback on a config. Requires the `serde` feature.
+///
+/// The callback receives JSON-serialized audit events during the
+/// sandbox lifecycle. See `ArapucaAuditCallback` for the safety
+/// contract.
+///
+/// Returns 0 on success, -1 on error.
+///
+/// # Safety
+/// `cfg` must be a valid pointer. `cb` must be a valid function pointer.
+/// `user_data` must remain valid until `arapuca_process_cleanup()`.
+#[cfg(feature = "serde")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_config_set_audit_callback(
+    cfg: *mut ArapucaConfig,
+    cb: Option<ArapucaAuditCallback>,
+    user_data: *mut std::ffi::c_void,
+) -> i32 {
+    clear_error();
+    let Some(cfg) = (unsafe { cfg.as_mut() }) else {
+        set_error("null config pointer");
+        return -1;
+    };
+    let Some(inner) = cfg.inner.as_mut() else {
+        set_error("config already freed");
+        return -1;
+    };
+    let Some(cb) = cb else {
+        set_error("null callback pointer");
+        return -1;
+    };
+    let sink = FfiAuditSink {
+        callback: cb,
+        user_data,
+    };
+    inner.audit_sink = Some(std::sync::Arc::new(sink));
+    0
+}
+
 /// Free a config. Safe to call with NULL.
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 
+pub mod audit;
 #[cfg(target_os = "linux")]
 pub mod cgroup;
 pub mod diskquota;

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -314,7 +314,12 @@ impl Sandbox for Darwin {
         // Start parent-PID watchdog (replaces PR_SET_PDEATHSIG).
         Self::start_parent_watchdog(pid);
 
-        Ok(Process { child, tmp_dir })
+        Ok(Process {
+            child,
+            tmp_dir,
+            audit_ctx: None,
+            final_stats: None,
+        })
     }
 
     fn available(&self) -> crate::Result<()> {

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -280,7 +280,7 @@ impl Sandbox for Darwin {
         }
 
         // Append caller-supplied env vars (filtered for safety).
-        env_vars.extend(crate::env::filter_caller_env(&cfg.env));
+        env_vars.extend(crate::env::filter_caller_env(&cfg.env).passed);
 
         command.env_clear();
         for (k, v) in &env_vars {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -194,6 +194,8 @@ impl Sandbox for Linux {
             tmp_dir,
             cgroup_path,
             cgroup_mgr: self.cgroup_mgr.clone(),
+            audit_ctx: None,
+            final_stats: None,
         })
     }
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -19,6 +19,10 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 
+use crate::audit::{
+    AuditContext, AuditEvent, AuditVerbosity, LayerDetail, SCHEMA_VERSION, SandboxLayer,
+    SkipReason, sanitize_audit_string,
+};
 use crate::cgroup::{CgroupLimits, CgroupManager};
 use crate::platform::Sandbox;
 use crate::{Config, Error, process::Process};
@@ -52,6 +56,40 @@ impl Sandbox for Linux {
 
         let tmp_dir = crate::env::make_tmp_dir(&cfg.task_id)?;
 
+        let audit_ctx = cfg
+            .audit_sink
+            .as_ref()
+            .map(|sink| AuditContext::new(Arc::clone(sink), cfg.audit_verbosity.clone()));
+
+        // Track layers for SandboxReady summary.
+        let mut applied_layers = Vec::new();
+        let mut skipped_layers = Vec::new();
+
+        // ── Emit SandboxInit ───────────────────────────────────────
+        if let Some(ref ctx) = audit_ctx {
+            let args_field = match ctx.verbosity() {
+                AuditVerbosity::Verbose => {
+                    Some(args.iter().map(|a| sanitize_audit_string(a)).collect())
+                }
+                _ => None,
+            };
+            ctx.emit(AuditEvent::SandboxInit {
+                timestamp: ctx.timestamp(),
+                wall_clock_epoch_ns: ctx.wall_clock_epoch_ns(),
+                schema_version: SCHEMA_VERSION,
+                task_id: sanitize_audit_string(&cfg.task_id),
+                phase: sanitize_audit_string(&cfg.phase),
+                command: sanitize_audit_string(cmd),
+                arg_count: args.len(),
+                args: args_field,
+                principal: cfg.audit_principal.as_deref().map(sanitize_audit_string),
+                correlation_id: cfg
+                    .audit_correlation_id
+                    .as_deref()
+                    .map(sanitize_audit_string),
+            })?;
+        }
+
         // Determine the actual command. We may wrap it with the
         // arapuca binary (Landlock+seccomp) and/or unshare (netns).
         let mut actual_cmd = cmd.to_string();
@@ -69,18 +107,85 @@ impl Sandbox for Linux {
             wrapper_args.extend(actual_args);
             actual_cmd = wrapper_path.to_string_lossy().into_owned();
             actual_args = wrapper_args;
+
+            let abi = crate::landlock::abi_version();
+            for layer in [
+                SandboxLayer::Landlock,
+                SandboxLayer::Seccomp,
+                SandboxLayer::Rlimit,
+                SandboxLayer::NoNewPrivs,
+            ] {
+                let detail = if layer == SandboxLayer::Landlock {
+                    Some(LayerDetail::Landlock {
+                        abi_version: abi,
+                        fully_enforced: abi >= 5,
+                    })
+                } else {
+                    None
+                };
+                if let Some(ref ctx) = audit_ctx {
+                    ctx.emit(AuditEvent::LayerApplied {
+                        timestamp: ctx.timestamp(),
+                        layer: layer.clone(),
+                        detail,
+                    })?;
+                }
+                applied_layers.push(layer);
+            }
+        } else {
+            // Wrapper binary absent or no paths configured — no
+            // Landlock/seccomp/rlimit/NO_NEW_PRIVS.
+            let has_paths =
+                !cfg.profile.read_paths.is_empty() || !cfg.profile.write_paths.is_empty();
+            let reason = if wrapper.is_none() && has_paths {
+                log::warn!("arapuca wrapper binary not found — no Landlock/seccomp applied");
+                SkipReason::ComponentMissing("wrapper binary not found".into())
+            } else {
+                SkipReason::NotConfigured
+            };
+            for layer in [
+                SandboxLayer::Landlock,
+                SandboxLayer::Seccomp,
+                SandboxLayer::Rlimit,
+                SandboxLayer::NoNewPrivs,
+            ] {
+                if let Some(ref ctx) = audit_ctx {
+                    ctx.emit(AuditEvent::LayerSkipped {
+                        timestamp: ctx.timestamp(),
+                        layer: layer.clone(),
+                        reason: reason.clone(),
+                    })?;
+                }
+                skipped_layers.push(layer);
+            }
         }
 
-        // Layer 2: Network namespace.
+        // ── Network namespace ──────────────────────────────────────
         let mut command = if cfg.profile.use_netns {
             let mut c = Command::new("unshare");
             c.args(["--user", "--net", "--map-current-user", "--"]);
             c.arg(&actual_cmd);
             c.args(&actual_args);
+            if let Some(ref ctx) = audit_ctx {
+                ctx.emit(AuditEvent::LayerApplied {
+                    timestamp: ctx.timestamp(),
+                    layer: SandboxLayer::NetworkNamespace,
+                    detail: None,
+                })?;
+            }
+            applied_layers.push(SandboxLayer::NetworkNamespace);
             c
         } else {
             let mut c = Command::new(&actual_cmd);
             c.args(&actual_args);
+            if let Some(ref ctx) = audit_ctx {
+                ctx.emit(AuditEvent::LayerSkipped {
+                    timestamp: ctx.timestamp(),
+                    layer: SandboxLayer::NetworkNamespace,
+                    reason: SkipReason::NotConfigured,
+                })?;
+            }
+            skipped_layers.push(SandboxLayer::NetworkNamespace);
             c
         };
 
@@ -109,7 +214,18 @@ impl Sandbox for Linux {
         }
 
         // Append caller-supplied env vars (filtered for safety).
-        env_vars.extend(crate::env::filter_caller_env(&cfg.env).passed);
+        let filter_result = crate::env::filter_caller_env(&cfg.env);
+        env_vars.extend(filter_result.passed);
+
+        // ── Emit EnvPolicy ─────────────────────────────────────────
+        if let Some(ref ctx) = audit_ctx {
+            ctx.emit(AuditEvent::EnvPolicy {
+                timestamp: ctx.timestamp(),
+                passed_keys: env_vars.iter().map(|(k, _)| k.clone()).collect(),
+                dropped: filter_result.dropped,
+            })?;
+        }
+        applied_layers.push(SandboxLayer::EnvFilter);
 
         command.env_clear();
         for (k, v) in &env_vars {
@@ -122,6 +238,39 @@ impl Sandbox for Linux {
         super::setup_stdio(&mut command, cfg.stderr, "stderr", Command::stderr)?;
 
         let fds_to_inherit: Vec<RawFd> = cfg.extra_fds.clone();
+
+        // ── Emit pre_exec layer events from parent ─────────────────
+        // pre_exec is async-signal-safe — no AuditContext allowed inside.
+        // We emit from the parent with the semantic "will be applied."
+        if let Some(ref ctx) = audit_ctx {
+            ctx.emit(AuditEvent::LayerApplied {
+                timestamp: ctx.timestamp(),
+                layer: SandboxLayer::Setsid,
+                detail: None,
+            })?;
+            ctx.emit(AuditEvent::LayerApplied {
+                timestamp: ctx.timestamp(),
+                layer: SandboxLayer::Pdeathsig,
+                detail: None,
+            })?;
+
+            let inherited: Vec<i32> = (0..fds_to_inherit.len()).map(|i| (3 + i) as i32).collect();
+            ctx.emit(AuditEvent::LayerApplied {
+                timestamp: ctx.timestamp(),
+                layer: SandboxLayer::FdSanitization,
+                detail: None,
+            })?;
+            ctx.emit(AuditEvent::FdInheritance {
+                timestamp: ctx.timestamp(),
+                inherited_fds: inherited,
+                stdin_redirected: cfg.stdin.is_some(),
+                stdout_redirected: cfg.stdout.is_some(),
+                stderr_redirected: cfg.stderr.is_some(),
+            })?;
+        }
+        applied_layers.push(SandboxLayer::Setsid);
+        applied_layers.push(SandboxLayer::Pdeathsig);
+        applied_layers.push(SandboxLayer::FdSanitization);
 
         // SAFETY: pre_exec runs between fork and exec. Only
         // async-signal-safe functions are permitted. We use raw libc
@@ -154,7 +303,54 @@ impl Sandbox for Linux {
             });
         }
 
-        // Create cgroup if available and limits are set.
+        // ── Emit policy summary events ─────────────────────────────
+        if let Some(ref ctx) = audit_ctx {
+            ctx.emit(AuditEvent::FilesystemPolicy {
+                timestamp: ctx.timestamp(),
+                read_paths: cfg
+                    .profile
+                    .read_paths
+                    .iter()
+                    .map(|p| sanitize_audit_string(&p.to_string_lossy()))
+                    .collect(),
+                write_paths: cfg
+                    .profile
+                    .write_paths
+                    .iter()
+                    .map(|p| sanitize_audit_string(&p.to_string_lossy()))
+                    .collect(),
+            })?;
+
+            ctx.emit(AuditEvent::ResourceLimits {
+                timestamp: ctx.timestamp(),
+                memory_mb: cfg.profile.max_memory_mb,
+                cpu_pct: cfg.profile.max_cpu_pct,
+                max_pids: cfg.profile.max_pids,
+                max_file_size_mb: cfg.profile.max_file_size_mb,
+                allow_exec: cfg.profile.allow_exec,
+            })?;
+
+            ctx.emit(AuditEvent::NetworkPolicy {
+                timestamp: ctx.timestamp(),
+                isolated: cfg.profile.use_netns,
+                proxy_socket: cfg
+                    .network_proxy_socket
+                    .as_ref()
+                    .map(|p| sanitize_audit_string(&p.to_string_lossy())),
+            })?;
+
+            let seccomp = crate::seccomp::summary();
+            ctx.emit(AuditEvent::SeccompPolicy {
+                timestamp: ctx.timestamp(),
+                tier1_kill_count: seccomp.tier1_kill_count,
+                tier2_eperm_count: seccomp.tier2_eperm_count,
+                socket_filter: seccomp.socket_filter,
+                prctl_filter: seccomp.prctl_filter,
+                allow_exec: cfg.profile.allow_exec,
+            })?;
+        }
+
+        // ── Create cgroup ──────────────────────────────────────────
         let limits = CgroupLimits {
             memory_max_mb: cfg.profile.max_memory_mb,
             pids_max: cfg.profile.max_pids,
@@ -165,14 +361,61 @@ impl Sandbox for Linux {
         if let Some(ref mgr) = self.cgroup_mgr {
             if limits.has_limits() {
                 match mgr.create(&cfg.task_id, &limits) {
-                    Ok(path) => cgroup_path = Some(path),
-                    Err(e) => log::warn!("cgroup creation failed: {e} (continuing without)"),
+                    Ok(path) => {
+                        if let Some(ref ctx) = audit_ctx {
+                            ctx.emit(AuditEvent::LayerApplied {
+                                timestamp: ctx.timestamp(),
+                                layer: SandboxLayer::Cgroup,
+                                detail: Some(LayerDetail::Cgroup {
+                                    path: sanitize_audit_string(&path.to_string_lossy()),
+                                }),
+                            })?;
+                        }
+                        applied_layers.push(SandboxLayer::Cgroup);
+                        cgroup_path = Some(path);
+                    }
+                    Err(e) => {
+                        log::warn!("cgroup creation failed: {e} (continuing without)");
+                        if let Some(ref ctx) = audit_ctx {
+                            ctx.emit(AuditEvent::LayerSkipped {
+                                timestamp: ctx.timestamp(),
+                                layer: SandboxLayer::Cgroup,
+                                reason: SkipReason::PartialFailure(format!("{e}")),
+                            })?;
+                        }
+                        skipped_layers.push(SandboxLayer::Cgroup);
+                    }
                 }
             }
+        } else if limits.has_limits() {
+            if let Some(ref ctx) = audit_ctx {
+                ctx.emit(AuditEvent::LayerSkipped {
+                    timestamp: ctx.timestamp(),
+                    layer: SandboxLayer::Cgroup,
+                    reason: SkipReason::NotAvailable,
+                })?;
+            }
+            skipped_layers.push(SandboxLayer::Cgroup);
         }
 
+        // ── Emit SandboxReady ──────────────────────────────────────
+        if let Some(ref ctx) = audit_ctx {
+            ctx.emit(AuditEvent::SandboxReady {
+                timestamp: ctx.timestamp(),
+                applied_layers: applied_layers.clone(),
+                skipped_layers: skipped_layers.clone(),
+            })?;
+        }
+
+        // ── Spawn ──────────────────────────────────────────────────
         let child = command.spawn().map_err(|e| {
-            // Clean up on failure.
+            if let Some(ref ctx) = audit_ctx {
+                let _ = ctx.emit(AuditEvent::LayerFailed {
+                    timestamp: ctx.timestamp(),
+                    layer: SandboxLayer::Setsid,
+                    error: sanitize_audit_string(&format!("spawn failed: {e}")),
+                });
+            }
             if let Some(ref path) = cgroup_path {
                 if let Some(ref mgr) = self.cgroup_mgr {
                     let _ = mgr.destroy(path);
@@ -182,10 +425,29 @@ impl Sandbox for Linux {
             Error::Process(format!("start sandboxed process: {e}"))
         })?;
 
+        // ── Emit ProcessStarted ────────────────────────────────────
+        if let Some(ref ctx) = audit_ctx {
+            ctx.emit(AuditEvent::ProcessStarted {
+                timestamp: ctx.timestamp(),
+                pid: child.id(),
+            })?;
+        }
+
         // Add subprocess PID to cgroup.
         if let (Some(mgr), Some(path)) = (&self.cgroup_mgr, &cgroup_path) {
             if let Err(e) = mgr.add_pid(path, child.id()) {
                 log::warn!("failed to add PID to cgroup: {e}");
+                if let Some(ref ctx) = audit_ctx {
+                    // Post-spawn: can't abort (child is running), so we
+                    // intentionally discard mandatory emit errors here.
+                    if let Err(ae) = ctx.emit(AuditEvent::LayerSkipped {
+                        timestamp: ctx.timestamp(),
+                        layer: SandboxLayer::Cgroup,
+                        reason: SkipReason::PartialFailure(format!("add_pid failed: {e}")),
+                    }) {
+                        log::error!("audit emit failed: {ae}");
+                    }
+                }
             }
         }
 
@@ -194,7 +456,7 @@ impl Sandbox for Linux {
             tmp_dir,
             cgroup_path,
             cgroup_mgr: self.cgroup_mgr.clone(),
-            audit_ctx: None,
+            audit_ctx,
             final_stats: None,
         })
     }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -237,7 +237,34 @@ impl Sandbox for Linux {
         super::setup_stdio(&mut command, cfg.stdout, "stdout", Command::stdout)?;
         super::setup_stdio(&mut command, cfg.stderr, "stderr", Command::stderr)?;
 
-        let fds_to_inherit: Vec<RawFd> = cfg.extra_fds.clone();
+        let mut fds_to_inherit: Vec<RawFd> = cfg.extra_fds.clone();
+
+        // ── Audit pipe for wrapper binary verification ─────────────
+        // When auditing is active and the wrapper binary is used, create
+        // a pipe so the wrapper can report which layers it actually
+        // applied. The write end is passed as an extra FD; the parent
+        // reads from the read end after spawn.
+        let audit_pipe = if audit_ctx.is_some() && use_landlock {
+            let mut fds = [0i32; 2];
+            // SAFETY: fds is a valid 2-element array. O_CLOEXEC prevents
+            // leaking the read end to the child process.
+            let ret = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+            if ret == 0 {
+                let target_fd = 3 + fds_to_inherit.len() as i32;
+                fds_to_inherit.push(fds[1]);
+                Some((fds[0], fds[1], target_fd))
+            } else {
+                log::warn!("audit pipe creation failed, continuing without");
+                None
+            }
+        } else {
+            None
+        };
+
+        // Add ARAPUCA_AUDIT_FD to wrapper env so it knows which FD to write to.
+        if let Some((_, _, target_fd)) = audit_pipe {
+            command.env("ARAPUCA_AUDIT_FD", target_fd.to_string());
+        }
 
         // ── Emit pre_exec layer events from parent ─────────────────
         // pre_exec is async-signal-safe — no AuditContext allowed inside.
@@ -416,6 +443,13 @@ impl Sandbox for Linux {
                     error: sanitize_audit_string(&format!("spawn failed: {e}")),
                 });
             }
+            if let Some((read_fd, write_fd, _)) = audit_pipe {
+                // SAFETY: valid FDs from pipe().
+                unsafe {
+                    libc::close(read_fd);
+                    libc::close(write_fd);
+                }
+            }
             if let Some(ref path) = cgroup_path {
                 if let Some(ref mgr) = self.cgroup_mgr {
                     let _ = mgr.destroy(path);
@@ -424,6 +458,19 @@ impl Sandbox for Linux {
             let _ = std::fs::remove_dir_all(&tmp_dir);
             Error::Process(format!("start sandboxed process: {e}"))
         })?;
+
+        // ── Read wrapper audit pipe ────────────────────────────────
+        // Close write end in parent (essential — otherwise EOF never
+        // arrives). Then read all lines until EOF. The wrapper writes
+        // events before execve; the write end closes at exec (CLOEXEC
+        // is cleared, but the wrapper explicitly closes it).
+        if let Some((read_fd, write_fd, _)) = audit_pipe {
+            // SAFETY: write_fd is a valid descriptor from pipe().
+            unsafe { libc::close(write_fd) };
+            validate_wrapper_audit(read_fd);
+            // SAFETY: read_fd is a valid descriptor from pipe().
+            unsafe { libc::close(read_fd) };
+        }
 
         // ── Emit ProcessStarted ────────────────────────────────────
         if let Some(ref ctx) = audit_ctx {
@@ -481,5 +528,59 @@ impl Sandbox for Linux {
 
     fn cgroups_available(&self) -> bool {
         self.cgroup_mgr.is_some()
+    }
+}
+
+/// Read and validate audit events from the wrapper binary's pipe.
+///
+/// The wrapper writes one JSON line per applied layer. We read until
+/// EOF (the wrapper closes the FD before execve) and validate that
+/// all expected layers were applied. Buffer bounded to 64 KiB to
+/// prevent OOM from a compromised wrapper.
+fn validate_wrapper_audit(read_fd: RawFd) {
+    const MAX_BUF: usize = 64 * 1024;
+    let mut buf = vec![0u8; MAX_BUF];
+    let mut total = 0;
+
+    loop {
+        // SAFETY: read_fd is a valid descriptor, buf is valid memory.
+        let n = unsafe {
+            libc::read(
+                read_fd,
+                buf[total..].as_mut_ptr().cast::<libc::c_void>(),
+                buf.len() - total,
+            )
+        };
+        if n == 0 {
+            break;
+        }
+        if n < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            log::warn!("wrapper audit pipe read error: {err}");
+            break;
+        }
+        total += n as usize;
+        if total >= MAX_BUF {
+            log::warn!("wrapper audit pipe exceeded 64 KiB, truncating");
+            break;
+        }
+    }
+
+    if total == 0 {
+        log::warn!("wrapper audit pipe: no events received (wrapper may have crashed)");
+        return;
+    }
+
+    let text = String::from_utf8_lossy(&buf[..total]);
+    let lines: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
+    log::info!("wrapper audit: received {} events", lines.len());
+
+    for line in &lines {
+        if line.contains(r#""status":"failed""#) {
+            log::error!("wrapper audit: layer failure reported: {line}");
+        }
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -109,7 +109,7 @@ impl Sandbox for Linux {
         }
 
         // Append caller-supplied env vars (filtered for safety).
-        env_vars.extend(crate::env::filter_caller_env(&cfg.env));
+        env_vars.extend(crate::env::filter_caller_env(&cfg.env).passed);
 
         command.env_clear();
         for (k, v) in &env_vars {

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -7,7 +7,12 @@
 use std::os::unix::io::RawFd;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
+use std::sync::Arc;
 
+use crate::audit::{
+    AuditContext, AuditEvent, AuditVerbosity, SCHEMA_VERSION, SandboxLayer, SkipReason,
+    sanitize_audit_string,
+};
 use crate::platform::Sandbox;
 use crate::{Config, Error, process::Process};
 
@@ -18,6 +23,68 @@ impl Sandbox for Other {
     fn launch(&self, cfg: &Config, cmd: &str, args: &[&str]) -> crate::Result<Process> {
         let tmp_dir = crate::env::make_tmp_dir(&cfg.task_id)?;
 
+        let audit_ctx = cfg
+            .audit_sink
+            .as_ref()
+            .map(|sink| AuditContext::new(Arc::clone(sink), cfg.audit_verbosity.clone()));
+
+        if let Some(ref ctx) = audit_ctx {
+            let args_field = match ctx.verbosity() {
+                AuditVerbosity::Verbose => {
+                    Some(args.iter().map(|a| sanitize_audit_string(a)).collect())
+                }
+                _ => None,
+            };
+            ctx.emit(AuditEvent::SandboxInit {
+                timestamp: ctx.timestamp(),
+                wall_clock_epoch_ns: ctx.wall_clock_epoch_ns(),
+                schema_version: SCHEMA_VERSION,
+                task_id: sanitize_audit_string(&cfg.task_id),
+                phase: sanitize_audit_string(&cfg.phase),
+                command: sanitize_audit_string(cmd),
+                arg_count: args.len(),
+                args: args_field,
+                principal: cfg.audit_principal.as_deref().map(sanitize_audit_string),
+                correlation_id: cfg
+                    .audit_correlation_id
+                    .as_deref()
+                    .map(sanitize_audit_string),
+            })?;
+
+            // All security layers are unavailable on this platform.
+            for layer in [
+                SandboxLayer::Landlock,
+                SandboxLayer::Seccomp,
+                SandboxLayer::Cgroup,
+                SandboxLayer::NetworkNamespace,
+                SandboxLayer::Rlimit,
+                SandboxLayer::NoNewPrivs,
+                SandboxLayer::Setsid,
+                SandboxLayer::Pdeathsig,
+            ] {
+                ctx.emit(AuditEvent::LayerSkipped {
+                    timestamp: ctx.timestamp(),
+                    layer,
+                    reason: SkipReason::PlatformUnsupported,
+                })?;
+            }
+
+            ctx.emit(AuditEvent::SandboxReady {
+                timestamp: ctx.timestamp(),
+                applied_layers: vec![SandboxLayer::EnvFilter, SandboxLayer::FdSanitization],
+                skipped_layers: vec![
+                    SandboxLayer::Landlock,
+                    SandboxLayer::Seccomp,
+                    SandboxLayer::Cgroup,
+                    SandboxLayer::NetworkNamespace,
+                    SandboxLayer::Rlimit,
+                    SandboxLayer::NoNewPrivs,
+                    SandboxLayer::Setsid,
+                    SandboxLayer::Pdeathsig,
+                ],
+            })?;
+        }
+
         let mut command = Command::new(cmd);
         command.args(args);
 
@@ -26,7 +93,17 @@ impl Sandbox for Other {
         }
 
         let mut env_vars = crate::env::minimal_env(&tmp_dir);
-        env_vars.extend(crate::env::filter_caller_env(&cfg.env).passed);
+        let filter_result = crate::env::filter_caller_env(&cfg.env);
+        env_vars.extend(filter_result.passed);
+
+        if let Some(ref ctx) = audit_ctx {
+            ctx.emit(AuditEvent::EnvPolicy {
+                timestamp: ctx.timestamp(),
+                passed_keys: env_vars.iter().map(|(k, _)| k.clone()).collect(),
+                dropped: filter_result.dropped,
+            })?;
+        }
+
         command.env_clear();
         for (k, v) in &env_vars {
             command.env(k, v);
@@ -65,10 +142,19 @@ impl Sandbox for Other {
             Error::Process(format!("start process: {e}"))
         })?;
 
+        if let Some(ref ctx) = audit_ctx {
+            if let Err(e) = ctx.emit(AuditEvent::ProcessStarted {
+                timestamp: ctx.timestamp(),
+                pid: child.id(),
+            }) {
+                log::error!("audit emit failed: {e}");
+            }
+        }
+
         Ok(Process {
             child,
             tmp_dir,
-            audit_ctx: None,
+            audit_ctx,
             final_stats: None,
         })
     }

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -26,7 +26,7 @@ impl Sandbox for Other {
         }
 
         let mut env_vars = crate::env::minimal_env(&tmp_dir);
-        env_vars.extend(crate::env::filter_caller_env(&cfg.env));
+        env_vars.extend(crate::env::filter_caller_env(&cfg.env).passed);
         command.env_clear();
         for (k, v) in &env_vars {
             command.env(k, v);

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -65,7 +65,12 @@ impl Sandbox for Other {
             Error::Process(format!("start process: {e}"))
         })?;
 
-        Ok(Process { child, tmp_dir })
+        Ok(Process {
+            child,
+            tmp_dir,
+            audit_ctx: None,
+            final_stats: None,
+        })
     }
 
     fn available(&self) -> crate::Result<()> {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -359,6 +359,8 @@ impl Sandbox for Windows {
             job_handle: Some(job_handle),
             container_name: container_name_owned,
             saved_dacls,
+            audit_ctx: None,
+            final_stats: None,
         })
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -873,7 +873,7 @@ fn rollback_appcontainer(
 }
 
 fn build_env(cfg: &Config, tmp_dir: &Path) -> Vec<(String, String)> {
-    let mut env: Vec<(String, String)> = crate::env::filter_caller_env(&cfg.env);
+    let mut env: Vec<(String, String)> = crate::env::filter_caller_env(&cfg.env).passed;
 
     if let Some(ref proxy) = cfg.network_proxy_socket {
         env.push((

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use crate::ResourceUsage;
-use crate::audit::AuditContext;
+use crate::audit::{AuditContext, AuditEvent};
 
 /// A running sandboxed subprocess.
 pub struct Process {
@@ -40,10 +40,8 @@ pub struct Process {
     #[cfg(windows)]
     pub(crate) saved_dacls: Vec<crate::platform::windows::SavedDacl>,
     /// Audit context for emitting lifecycle events.
-    #[allow(dead_code)]
     pub(crate) audit_ctx: Option<AuditContext>,
     /// Resource stats captured in wait() while cgroup still exists.
-    #[allow(dead_code)]
     pub(crate) final_stats: Option<ResourceUsage>,
 }
 
@@ -63,9 +61,46 @@ impl Process {
     /// Wait for the process to exit and return the exit status.
     #[cfg(not(windows))]
     pub fn wait(&mut self) -> crate::Result<std::process::ExitStatus> {
-        self.child
+        let pid = self.child.id();
+        let status = self
+            .child
             .wait()
-            .map_err(|e| crate::Error::Process(format!("wait: {e}")))
+            .map_err(|e| crate::Error::Process(format!("wait: {e}")))?;
+
+        // Capture stats while cgroup still exists (before cleanup
+        // destroys it). Eliminates the TOCTOU gap.
+        self.final_stats = Some(self.resource_stats());
+        let oom = self.oom_count();
+
+        if let Some(ref ctx) = self.audit_ctx {
+            use std::os::unix::process::ExitStatusExt;
+            // Post-exit: can't abort, so discard mandatory emit errors.
+            if let Err(e) = ctx.emit(AuditEvent::ProcessExited {
+                timestamp: ctx.timestamp(),
+                pid,
+                exit_code: status.code(),
+                signal: status.signal(),
+                oom_kill_count: oom,
+            }) {
+                log::error!("audit emit failed: {e}");
+            }
+
+            if let Some(ref stats) = self.final_stats {
+                if let Err(e) = ctx.emit(AuditEvent::ResourceUsage {
+                    timestamp: ctx.timestamp(),
+                    memory_current_bytes: stats.memory_current_bytes,
+                    memory_peak_bytes: stats.memory_peak_bytes,
+                    cpu_seconds: stats.cpu_usage_seconds,
+                    pid_count: stats.pid_count,
+                    io_read_bytes: stats.io_read_bytes,
+                    io_write_bytes: stats.io_write_bytes,
+                }) {
+                    log::error!("audit emit failed: {e}");
+                }
+            }
+        }
+
+        Ok(status)
     }
 
     /// Wait for the process to exit and return the exit status.
@@ -103,7 +138,22 @@ impl Process {
             )));
         }
 
-        Ok(std::process::ExitStatus::from_raw(exit_code))
+        let status = std::process::ExitStatus::from_raw(exit_code);
+        let pid = self.process_id;
+
+        if let Some(ref ctx) = self.audit_ctx {
+            if let Err(e) = ctx.emit(AuditEvent::ProcessExited {
+                timestamp: ctx.timestamp(),
+                pid,
+                exit_code: Some(exit_code as i32),
+                signal: None,
+                oom_kill_count: 0,
+            }) {
+                log::error!("audit emit failed: {e}");
+            }
+        }
+
+        Ok(status)
     }
 
     /// Read resource usage from the agent's cgroup.
@@ -134,23 +184,51 @@ impl Process {
     ///
     /// Must only be called after `wait()` returns.
     pub fn cleanup(self) {
+        let mut cgroup_destroyed = false;
         #[cfg(target_os = "linux")]
         if let (Some(mgr), Some(path)) = (&self.cgroup_mgr, &self.cgroup_path) {
-            let _ = mgr.destroy(path);
+            cgroup_destroyed = mgr.destroy(path).is_ok();
         }
+
+        #[cfg(windows)]
+        let mut dacls_restored = true;
+        #[cfg(windows)]
+        let mut container_deleted = false;
         #[cfg(windows)]
         {
             for saved in &self.saved_dacls {
                 if let Err(e) = crate::platform::windows::restore_dacl(saved) {
                     log::warn!("failed to restore DACL: {e}");
+                    dacls_restored = false;
                 }
             }
             if let Some(ref name) = self.container_name {
-                let _ = crate::platform::windows::delete_app_container(name);
+                container_deleted = crate::platform::windows::delete_app_container(name).is_ok();
             }
         }
-        if self.tmp_dir.exists() {
-            let _ = std::fs::remove_dir_all(&self.tmp_dir);
+
+        let tmpdir_removed = if self.tmp_dir.exists() {
+            std::fs::remove_dir_all(&self.tmp_dir).is_ok()
+        } else {
+            true
+        };
+
+        if let Some(ref ctx) = self.audit_ctx {
+            if let Err(e) = ctx.emit(AuditEvent::SandboxCleanup {
+                timestamp: ctx.timestamp(),
+                cgroup_destroyed,
+                tmpdir_removed,
+                #[cfg(windows)]
+                dacls_restored: Some(dacls_restored),
+                #[cfg(not(windows))]
+                dacls_restored: None,
+                #[cfg(windows)]
+                container_deleted: Some(container_deleted),
+                #[cfg(not(windows))]
+                container_deleted: None,
+            }) {
+                log::error!("audit emit failed: {e}");
+            }
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -40,8 +40,10 @@ pub struct Process {
     #[cfg(windows)]
     pub(crate) saved_dacls: Vec<crate::platform::windows::SavedDacl>,
     /// Audit context for emitting lifecycle events.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) audit_ctx: Option<AuditContext>,
     /// Resource stats captured in wait() while cgroup still exists.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) final_stats: Option<ResourceUsage>,
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use crate::ResourceUsage;
+use crate::audit::AuditContext;
 
 /// A running sandboxed subprocess.
 pub struct Process {
@@ -38,6 +39,12 @@ pub struct Process {
     /// Saved DACLs for restoration during cleanup.
     #[cfg(windows)]
     pub(crate) saved_dacls: Vec<crate::platform::windows::SavedDacl>,
+    /// Audit context for emitting lifecycle events.
+    #[allow(dead_code)]
+    pub(crate) audit_ctx: Option<AuditContext>,
+    /// Resource stats captured in wait() while cgroup still exists.
+    #[allow(dead_code)]
+    pub(crate) final_stats: Option<ResourceUsage>,
 }
 
 impl Process {

--- a/src/process.rs
+++ b/src/process.rs
@@ -184,6 +184,7 @@ impl Process {
     ///
     /// Must only be called after `wait()` returns.
     pub fn cleanup(self) {
+        #[allow(unused_mut)]
         let mut cgroup_destroyed = false;
         #[cfg(target_os = "linux")]
         if let (Some(mgr), Some(path)) = (&self.cgroup_mgr, &self.cgroup_path) {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,6 +1,9 @@
 #[cfg(unix)]
 use std::os::unix::io::RawFd;
 use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::audit::{AuditSink, AuditVerbosity};
 
 /// Filesystem and resource restrictions for a sandboxed process.
 #[derive(Debug, Clone, Default)]
@@ -24,7 +27,7 @@ pub struct Profile {
 }
 
 /// Full configuration for launching a sandboxed process.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Config {
     /// Security restrictions to apply.
     pub profile: Profile,
@@ -57,6 +60,47 @@ pub struct Config {
     /// LD_*, DYLD_*, and other dangerous names are silently dropped.
     /// If the same key is added multiple times, the last value wins.
     pub env: Vec<(String, String)>,
+    /// Optional audit event sink. When None, no events are emitted
+    /// and zero audit overhead is incurred.
+    pub audit_sink: Option<Arc<dyn AuditSink>>,
+    /// Controls how much detail audit events include.
+    pub audit_verbosity: AuditVerbosity,
+    /// Caller-supplied principal identity for audit records.
+    pub audit_principal: Option<String>,
+    /// Caller-supplied correlation ID for distributed tracing.
+    pub audit_correlation_id: Option<String>,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("Config");
+        s.field("profile", &self.profile)
+            .field("socket_dir", &self.socket_dir)
+            .field("task_id", &self.task_id)
+            .field("phase", &self.phase)
+            .field("work_dir", &self.work_dir);
+        #[cfg(unix)]
+        {
+            s.field("stdin", &self.stdin)
+                .field("stdout", &self.stdout)
+                .field("stderr", &self.stderr)
+                .field("extra_fds", &self.extra_fds);
+        }
+        s.field("network_proxy_socket", &self.network_proxy_socket)
+            .field("env", &format!("[{} vars]", self.env.len()))
+            .field(
+                "audit_sink",
+                if self.audit_sink.is_some() {
+                    &"Some(<AuditSink>)"
+                } else {
+                    &"None"
+                },
+            )
+            .field("audit_verbosity", &self.audit_verbosity)
+            .field("audit_principal", &self.audit_principal)
+            .field("audit_correlation_id", &self.audit_correlation_id)
+            .finish()
+    }
 }
 
 /// Resource usage statistics from cgroups v2.

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -224,6 +224,25 @@ fn tier2_eperm_syscalls() -> Vec<i64> {
     ]
 }
 
+/// Summary of the seccomp filter policy for audit reporting.
+pub(crate) struct SeccompSummary {
+    pub tier1_kill_count: usize,
+    pub tier2_eperm_count: usize,
+    pub socket_filter: bool,
+    pub prctl_filter: bool,
+}
+
+// NOTE: socket_filter and prctl_filter are hardcoded to match
+// build_filter(). Update these if those filters become conditional.
+pub(crate) fn summary() -> SeccompSummary {
+    SeccompSummary {
+        tier1_kill_count: tier1_kill_syscalls().len(),
+        tier2_eperm_count: tier2_eperm_syscalls().len(),
+        socket_filter: true,
+        prctl_filter: true,
+    }
+}
+
 /// Determine the target architecture for seccompiler.
 fn target_arch() -> crate::Result<TargetArch> {
     #[cfg(target_arch = "x86_64")]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -1,0 +1,327 @@
+//! Audit event lifecycle integration tests.
+//!
+//! Launches a sandboxed subprocess with an audit sink and verifies
+//! the complete event sequence from SandboxInit through SandboxCleanup.
+#![cfg(target_os = "linux")]
+
+use std::sync::{Arc, Mutex};
+
+use arapuca::audit::{AuditEvent, AuditSink, AuditVerbosity, SandboxLayer};
+use arapuca::platform::{Sandbox, new};
+use arapuca::{Config, Profile};
+
+struct VecSink(Mutex<Vec<AuditEvent>>);
+
+impl AuditSink for VecSink {
+    fn emit(&self, event: AuditEvent) {
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).push(event);
+    }
+}
+
+fn event_names(events: &[AuditEvent]) -> Vec<&'static str> {
+    events
+        .iter()
+        .map(|e| match e {
+            AuditEvent::SandboxInit { .. } => "SandboxInit",
+            AuditEvent::LayerApplied { .. } => "LayerApplied",
+            AuditEvent::LayerSkipped { .. } => "LayerSkipped",
+            AuditEvent::LayerFailed { .. } => "LayerFailed",
+            AuditEvent::EnvPolicy { .. } => "EnvPolicy",
+            AuditEvent::FilesystemPolicy { .. } => "FilesystemPolicy",
+            AuditEvent::ResourceLimits { .. } => "ResourceLimits",
+            AuditEvent::NetworkPolicy { .. } => "NetworkPolicy",
+            AuditEvent::SeccompPolicy { .. } => "SeccompPolicy",
+            AuditEvent::FdInheritance { .. } => "FdInheritance",
+            AuditEvent::SandboxReady { .. } => "SandboxReady",
+            AuditEvent::ProcessStarted { .. } => "ProcessStarted",
+            AuditEvent::ProcessExited { .. } => "ProcessExited",
+            AuditEvent::ResourceUsage { .. } => "ResourceUsage",
+            AuditEvent::SandboxCleanup { .. } => "SandboxCleanup",
+            _ => "Unknown",
+        })
+        .collect()
+}
+
+fn basic_config(sink: Arc<dyn AuditSink>) -> Config {
+    Config {
+        profile: Profile::default(),
+        socket_dir: std::path::PathBuf::new(),
+        task_id: "audit-test".into(),
+        phase: "test".into(),
+        work_dir: None,
+        stdin: None,
+        stdout: None,
+        stderr: None,
+        extra_fds: Vec::new(),
+        network_proxy_socket: None,
+        env: Vec::new(),
+        audit_sink: Some(sink),
+        audit_verbosity: AuditVerbosity::Standard,
+        audit_principal: Some("test-user".into()),
+        audit_correlation_id: Some("corr-123".into()),
+    }
+}
+
+#[test]
+fn full_lifecycle_event_sequence() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let cfg = basic_config(sink);
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &[]).unwrap();
+    let status = proc.wait().unwrap();
+    assert!(status.success());
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    let names = event_names(&events);
+
+    // First event must be SandboxInit.
+    assert_eq!(names[0], "SandboxInit");
+
+    // SandboxReady must appear before ProcessStarted.
+    let ready_pos = names.iter().position(|n| *n == "SandboxReady").unwrap();
+    let started_pos = names.iter().position(|n| *n == "ProcessStarted").unwrap();
+    assert!(ready_pos < started_pos);
+
+    // ProcessExited must appear after ProcessStarted.
+    let exited_pos = names.iter().position(|n| *n == "ProcessExited").unwrap();
+    assert!(exited_pos > started_pos);
+
+    // ResourceUsage must appear after ProcessExited.
+    let usage_pos = names.iter().position(|n| *n == "ResourceUsage").unwrap();
+    assert!(usage_pos > exited_pos);
+
+    // SandboxCleanup must be the last event.
+    assert_eq!(*names.last().unwrap(), "SandboxCleanup");
+
+    // No unknown event types (catches new variants silently absorbed by wildcard).
+    assert!(
+        !names.iter().any(|n| *n == "Unknown"),
+        "unknown event type in sequence: {names:?}"
+    );
+
+    // Policy events must appear between SandboxInit and SandboxReady.
+    for policy in [
+        "EnvPolicy",
+        "FilesystemPolicy",
+        "ResourceLimits",
+        "NetworkPolicy",
+    ] {
+        let pos = names.iter().position(|n| *n == policy).unwrap();
+        assert!(
+            pos > 0 && pos < ready_pos,
+            "{policy} not between init and ready"
+        );
+    }
+}
+
+#[test]
+fn sandbox_init_fields() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let cfg = basic_config(sink);
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &[]).unwrap();
+    proc.wait().unwrap();
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    match &events[0] {
+        AuditEvent::SandboxInit {
+            wall_clock_epoch_ns,
+            schema_version,
+            task_id,
+            phase,
+            command,
+            arg_count,
+            args,
+            principal,
+            correlation_id,
+            ..
+        } => {
+            assert!(*wall_clock_epoch_ns > 1_700_000_000_000_000_000);
+            assert_eq!(*schema_version, 1);
+            assert_eq!(task_id, "audit-test");
+            assert_eq!(phase, "test");
+            assert_eq!(command, "/bin/true");
+            assert_eq!(*arg_count, 0);
+            assert!(args.is_none());
+            assert_eq!(principal.as_deref(), Some("test-user"));
+            assert_eq!(correlation_id.as_deref(), Some("corr-123"));
+        }
+        _ => panic!("first event should be SandboxInit"),
+    }
+}
+
+#[test]
+fn verbose_mode_includes_args() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let mut cfg = basic_config(sink);
+    cfg.audit_verbosity = AuditVerbosity::Verbose;
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &["arg1", "arg2"]).unwrap();
+    proc.wait().unwrap();
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    match &events[0] {
+        AuditEvent::SandboxInit {
+            arg_count, args, ..
+        } => {
+            assert_eq!(*arg_count, 2);
+            let args = args.as_ref().unwrap();
+            assert_eq!(args, &["arg1", "arg2"]);
+        }
+        _ => panic!("first event should be SandboxInit"),
+    }
+}
+
+#[test]
+fn standard_mode_omits_args() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let cfg = basic_config(sink);
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &["redacted"]).unwrap();
+    proc.wait().unwrap();
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    match &events[0] {
+        AuditEvent::SandboxInit {
+            arg_count, args, ..
+        } => {
+            assert_eq!(*arg_count, 1);
+            assert!(args.is_none());
+        }
+        _ => panic!("first event should be SandboxInit"),
+    }
+}
+
+#[test]
+fn process_exited_captures_exit_code() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let cfg = basic_config(sink);
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/false", &[]).unwrap();
+    let status = proc.wait().unwrap();
+    assert!(!status.success());
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    let exited = events
+        .iter()
+        .find(|e| matches!(e, AuditEvent::ProcessExited { .. }));
+    match exited.unwrap() {
+        AuditEvent::ProcessExited {
+            exit_code, signal, ..
+        } => {
+            assert_eq!(*exit_code, Some(1));
+            assert_eq!(*signal, None);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn sandbox_ready_lists_layers() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let cfg = basic_config(sink);
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &[]).unwrap();
+    proc.wait().unwrap();
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    let ready = events
+        .iter()
+        .find(|e| matches!(e, AuditEvent::SandboxReady { .. }));
+    match ready.unwrap() {
+        AuditEvent::SandboxReady {
+            applied_layers,
+            skipped_layers,
+            ..
+        } => {
+            // EnvFilter and pre_exec layers are always applied.
+            assert!(applied_layers.contains(&SandboxLayer::EnvFilter));
+            assert!(applied_layers.contains(&SandboxLayer::Setsid));
+            assert!(applied_layers.contains(&SandboxLayer::Pdeathsig));
+            assert!(applied_layers.contains(&SandboxLayer::FdSanitization));
+            // Without paths configured, wrapper layers are skipped.
+            assert!(skipped_layers.contains(&SandboxLayer::Landlock));
+            assert!(skipped_layers.contains(&SandboxLayer::Seccomp));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn no_events_without_sink() {
+    let cfg = Config {
+        profile: Profile::default(),
+        socket_dir: std::path::PathBuf::new(),
+        task_id: "no-audit".into(),
+        phase: "test".into(),
+        work_dir: None,
+        stdin: None,
+        stdout: None,
+        stderr: None,
+        extra_fds: Vec::new(),
+        network_proxy_socket: None,
+        env: Vec::new(),
+        audit_sink: None,
+        audit_verbosity: AuditVerbosity::Standard,
+        audit_principal: None,
+        audit_correlation_id: None,
+    };
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &[]).unwrap();
+    proc.wait().unwrap();
+    proc.cleanup();
+    // No panic, no events — zero overhead path works.
+}
+
+#[test]
+fn env_filtering_audited() {
+    let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+    let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+    let mut cfg = basic_config(sink);
+    cfg.env = vec![
+        ("SAFE_VAR".into(), "ok".into()),
+        ("LD_PRELOAD".into(), "/evil.so".into()),
+    ];
+
+    let sb = new().unwrap();
+    let mut proc = sb.launch(&cfg, "/bin/true", &[]).unwrap();
+    proc.wait().unwrap();
+    proc.cleanup();
+
+    let events = vec_sink.0.lock().unwrap();
+    let env_event = events
+        .iter()
+        .find(|e| matches!(e, AuditEvent::EnvPolicy { .. }));
+    match env_event.unwrap() {
+        AuditEvent::EnvPolicy {
+            passed_keys,
+            dropped,
+            ..
+        } => {
+            assert!(passed_keys.contains(&"SAFE_VAR".to_string()));
+            assert!(!passed_keys.iter().any(|k| k == "LD_PRELOAD"));
+            assert_eq!(dropped.len(), 1);
+            assert_eq!(dropped[0].key, "LD_PRELOAD");
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Arapuca correctly isolates workloads but produces no structured record of what it did. An orchestrator deploying it at scale cannot prove which restrictions were applied, detect silent degradation (e.g., missing wrapper binary means no   Landlock/seccomp), or feed sandbox decisions into a compliance pipeline.

This PR adds an optional AuditSink trait that receives structured events covering the full sandbox lifecycle — what was
applied, what was skipped and why, what env vars were filtered, and what resources were consumed. Zero cost when  unused.