### PR TITLE
feat: add --cwd flag to set sandbox working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ arapuca run \
 | Flag | Description |
 |------|-------------|
 | `-v /path[:ro]` | Allow path access (read-write default, `:ro` for read-only) |
+| `--cwd /path` | Set working directory (must be within a mount) |
 | `--env KEY=VALUE` | Pass environment variable |
 | `--timeout N` | Kill after N seconds |
 | `--memory N` | Memory limit in MB |

--- a/doc/arapuca.1.md
+++ b/doc/arapuca.1.md
@@ -57,6 +57,13 @@ preserved.
     */proc*, */sys*, and blanket */dev* are NOT included by default.
     Use **-v /tmp** to grant write access to all of */tmp*.
 
+**-\-cwd** *path*
+:   Set the working directory for the sandboxed process. The path must
+    be absolute, must exist, must be a directory, and must be within a
+    mounted path (default or **-v**). Symlinks are resolved before the
+    containment check. Useful for programmatic callers that need to set
+    the working directory without shell wrappers.
+
 **-\-env** *KEY*=*VALUE*
 :   Pass an environment variable to the sandboxed process. Dangerous
     variables (**LD_PRELOAD**, **ARAPUCA_\***, **DYLD_\***, interpreter

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -348,6 +348,7 @@ fn run_subcommand(args: &[String]) {
     let mut cpus: Option<u32> = None;
     let mut pids: Option<u32> = None;
     let mut task_id: Option<String> = None;
+    let mut cwd: Option<PathBuf> = None;
     let mut seccomp_profile = arapuca::SeccompProfile::Strict;
     #[cfg(unix)]
     let mut tty = false;
@@ -367,6 +368,7 @@ fn run_subcommand(args: &[String]) {
             eprintln!();
             eprintln!("flags:");
             eprintln!("  -v /path[:ro]      allow path access (rw default, :ro read-only)");
+            eprintln!("  --cwd /path        set working directory (must be within a mount)");
             eprintln!("  --env KEY=VALUE    pass environment variable");
             eprintln!("  --timeout N        kill after N seconds");
             eprintln!("  --memory N         memory limit in MB");
@@ -551,6 +553,19 @@ fn run_subcommand(args: &[String]) {
                     }
                 };
             }
+            "--cwd" => {
+                i += 1;
+                let path = flag_args.get(i).unwrap_or_else(|| {
+                    eprintln!("--cwd requires a path");
+                    std::process::exit(125);
+                });
+                let p = PathBuf::from(path);
+                if !p.is_absolute() {
+                    eprintln!("arapuca run: --cwd path must be absolute: {}", p.display());
+                    std::process::exit(125);
+                }
+                cwd = Some(p);
+            }
             other => {
                 eprintln!("arapuca run: unknown flag: {other}");
                 eprintln!("hint: did you forget '--' before the command?");
@@ -602,6 +617,29 @@ fn run_subcommand(args: &[String]) {
         });
     }
 
+    if let Some(ref cwd_path) = cwd {
+        let canonical = cwd_path.canonicalize().unwrap_or_else(|e| {
+            eprintln!("arapuca run: --cwd path cannot be resolved: {e}");
+            std::process::exit(125);
+        });
+        if !canonical.is_dir() {
+            eprintln!(
+                "arapuca run: --cwd path is not a directory: {}",
+                canonical.display()
+            );
+            std::process::exit(125);
+        }
+        let in_mounts = read_paths
+            .iter()
+            .chain(write_paths.iter())
+            .any(|p| canonical.starts_with(p));
+        if !in_mounts {
+            eprintln!("arapuca run: --cwd path must be within a mounted path");
+            std::process::exit(125);
+        }
+        cwd = Some(canonical);
+    }
+
     let task = task_id.unwrap_or_else(|| format!("run-{}", std::process::id()));
     arapuca::sanitize_task_id(&task).unwrap_or_else(|e| {
         eprintln!("arapuca run: {e}");
@@ -648,7 +686,7 @@ fn run_subcommand(args: &[String]) {
         socket_dir: PathBuf::new(),
         task_id: task,
         phase: "run".into(),
-        work_dir: None,
+        work_dir: cwd,
         #[cfg(unix)]
         stdin: None,
         #[cfg(unix)]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -789,6 +789,191 @@ fn wait_with_timeout(
     }
 }
 
+// ─── --cwd tests ─────────────────────────────────────────────
+
+#[test]
+fn cwd_sets_working_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir_str = dir.path().to_str().unwrap();
+    let vol = format!("{dir_str}:ro");
+
+    let output = Command::new(arapuca_bin())
+        .args(["run", "--cwd", dir_str, "-v", &vol, "--", "/bin/pwd"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "pwd should succeed with --cwd");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        dir_str,
+        "working directory should match --cwd"
+    );
+}
+
+#[test]
+fn cwd_without_mount_rejected() {
+    let status = Command::new(arapuca_bin())
+        .args(["run", "--cwd", "/opt", "--", "/bin/true"])
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(125),
+        "--cwd without matching mount should exit 125"
+    );
+}
+
+#[test]
+fn cwd_relative_path_rejected() {
+    let status = Command::new(arapuca_bin())
+        .args(["run", "--cwd", "./relative", "--", "/bin/true"])
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(125),
+        "--cwd with relative path should exit 125"
+    );
+}
+
+#[test]
+fn cwd_nonexistent_path_rejected() {
+    let status = Command::new(arapuca_bin())
+        .args([
+            "run",
+            "--cwd",
+            "/nonexistent-arapuca-test-path",
+            "-v",
+            "/nonexistent-arapuca-test-path:ro",
+            "--",
+            "/bin/true",
+        ])
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(125),
+        "--cwd with nonexistent path should exit 125"
+    );
+}
+
+#[test]
+fn cwd_symlink_outside_mount_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let link = dir.path().join("escape");
+    std::os::unix::fs::symlink("/etc", &link).unwrap();
+
+    let dir_str = dir.path().to_str().unwrap();
+    let vol = format!("{dir_str}:ro");
+    let link_str = link.to_str().unwrap();
+
+    let status = Command::new(arapuca_bin())
+        .args(["run", "--cwd", link_str, "-v", &vol, "--", "/bin/true"])
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(125),
+        "--cwd symlink pointing outside mount should exit 125"
+    );
+}
+
+#[test]
+fn cwd_file_not_directory_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("not-a-dir.txt");
+    std::fs::write(&file, "").unwrap();
+
+    let dir_str = dir.path().to_str().unwrap();
+    let vol = format!("{dir_str}:ro");
+    let file_str = file.to_str().unwrap();
+
+    let status = Command::new(arapuca_bin())
+        .args(["run", "--cwd", file_str, "-v", &vol, "--", "/bin/true"])
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(125),
+        "--cwd pointing to a file should exit 125"
+    );
+}
+
+#[test]
+fn cwd_with_default_paths() {
+    let output = Command::new(arapuca_bin())
+        .args(["run", "--cwd", "/tmp", "--", "/bin/pwd"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "--cwd /tmp should work via default read paths"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "/tmp",
+        "working directory should be /tmp"
+    );
+}
+
+#[test]
+fn cwd_subdirectory_of_mount_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let sub = dir.path().join("child");
+    std::fs::create_dir(&sub).unwrap();
+
+    let dir_str = dir.path().to_str().unwrap();
+    let sub_str = sub.to_str().unwrap();
+    let vol = format!("{dir_str}:ro");
+
+    let output = Command::new(arapuca_bin())
+        .args(["run", "--cwd", sub_str, "-v", &vol, "--", "/bin/pwd"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "--cwd subdirectory of mount should succeed"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        sub_str,
+        "working directory should match --cwd subdirectory"
+    );
+}
+
+#[test]
+fn cwd_with_write_mount_allows_writing() {
+    let dir = tempfile::tempdir().unwrap();
+    let dir_str = dir.path().to_str().unwrap();
+
+    let output = Command::new(arapuca_bin())
+        .args([
+            "run",
+            "--cwd",
+            dir_str,
+            "-v",
+            dir_str,
+            "--",
+            "/bin/sh",
+            "-c",
+            "echo ok > testfile && cat testfile",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "--cwd with rw mount should allow writes"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "ok",
+        "write to cwd should succeed with rw mount"
+    );
+}
+
 // ─── /tmp write restriction tests ─────────────────────────────
 
 #[test]


### PR DESCRIPTION
Allow callers to set the working directory for sandboxed processes without resorting to shell wrappers like `sh -c "cd $DIR && exec ..."`, which are vulnerable to shell injection.
