### PR TITLE
feat: add macOS Seatbelt network mode and harden sandbox profile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use validate::{MAX_GUEST_FILE_SIZE, MAX_GUEST_WRITE_FILES, sanitize_task_id}
 #[cfg(unix)]
 pub use validate::{
     reject_cgroup_paths, validate_guest_file_content, validate_guest_path,
-    validate_guest_permissions,
+    validate_guest_permissions, validate_work_dir,
 };
 
 /// Result type for arapuca operations.

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -121,12 +121,17 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
         "/opt/homebrew",
         "/Library/Frameworks",
         "/System",
-        "/dev",
         "/private/var/select",
         "/private/var/db/timezone",
     ] {
         writeln!(profile, "(allow file-read* (subpath \"{sys_path}\"))").unwrap();
     }
+    // Specific device nodes — not blanket /dev which would expose
+    // disk devices, DTrace, and pseudo-terminals.
+    for dev in &["/dev/null", "/dev/zero", "/dev/urandom", "/dev/random"] {
+        writeln!(profile, "(allow file-read* (literal \"{dev}\"))").unwrap();
+    }
+    writeln!(profile, "(allow file-read* (subpath \"/dev/fd\"))").unwrap();
     writeln!(profile).unwrap();
 
     // Specific /etc files (not the whole directory).

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -24,6 +24,13 @@ pub struct ProfileData {
     pub control_socket: Option<String>,
     /// Path to the LLM proxy socket.
     pub llm_socket: Option<String>,
+    /// Allow outbound network access (TCP + DNS via mDNSResponder).
+    ///
+    /// Maps from `SeccompProfile::Baseline` on the caller side. When
+    /// true, the profile grants unrestricted TCP outbound and the Mach
+    /// IPC services needed for DNS and TLS on macOS. There is no
+    /// per-host filtering (unlike Linux's netns + CONNECT proxy).
+    pub allow_network: bool,
 }
 
 /// Validate that a path contains only safe characters for embedding in
@@ -37,8 +44,12 @@ pub fn validate_profile_path(path: &str) -> crate::Result<()> {
     if path.is_empty() {
         return Err(Error::Validation("empty path".into()));
     }
+    if path.split('/').any(|c| c == "..") {
+        return Err(Error::Validation(format!("path contains '..': {path}")));
+    }
     for ch in path.chars() {
-        if !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '/' | '_' | '.' | ' ' | '-' | '@') {
+        if !matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '/' | '_' | '.' | ' ' | '-' | '@' | '+')
+        {
             return Err(Error::Validation(format!(
                 "invalid character in sandbox profile path: {:?}",
                 ch
@@ -127,16 +138,11 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
         "/private/etc/hosts",
         "/private/etc/resolv.conf",
         "/private/etc/localtime",
-        "/private/etc/ssl/cert.pem",
     ] {
         writeln!(profile, "(allow file-read* (literal \"{etc_file}\"))").unwrap();
     }
-    // Allow reading /etc/ssl directory for certificate lookup.
-    writeln!(
-        profile,
-        "(allow file-read* (subpath \"/private/etc/ssl/certs\"))"
-    )
-    .unwrap();
+    // Allow reading /etc/ssl for certificates and OpenSSL configuration.
+    writeln!(profile, "(allow file-read* (subpath \"/private/etc/ssl\"))").unwrap();
     writeln!(profile).unwrap();
 
     // User read paths.
@@ -178,16 +184,108 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
     }
     writeln!(profile).unwrap();
 
-    // Network: deny all TCP/UDP (via deny default). Only allow Unix
-    // domain sockets to specific paths.
-    if data.control_socket.is_some() || data.llm_socket.is_some() {
-        writeln!(profile, "; Unix sockets").unwrap();
-        writeln!(profile, "(allow network-outbound (remote unix))").unwrap();
+    // Network: baseline mode allows TCP outbound and DNS via
+    // mDNSResponder. Strict mode (default) blocks all network via
+    // (deny default).
+    if data.allow_network {
+        writeln!(profile, "; Network (baseline mode)").unwrap();
+        for meta_path in &[
+            "/private",
+            "/private/var",
+            "/private/etc",
+            "/usr",
+            "/System",
+            "/Library",
+            "/var",
+            "/etc",
+            "/tmp",
+        ] {
+            writeln!(
+                profile,
+                "(allow file-read-metadata (subpath \"{meta_path}\"))"
+            )
+            .unwrap();
+        }
+        writeln!(profile, "(allow network-outbound (remote tcp))").unwrap();
+        // mDNSResponder — DNS resolution on macOS goes through this socket.
+        writeln!(
+            profile,
+            "(allow network-outbound (remote unix-socket (path-literal \"/private/var/run/mDNSResponder\")))"
+        )
+        .unwrap();
+        writeln!(profile, "(allow network-outbound").unwrap();
+        writeln!(profile, "  (control-name \"com.apple.netsrc\")").unwrap();
+        writeln!(
+            profile,
+            "  (control-name \"com.apple.network.statistics\"))"
+        )
+        .unwrap();
+        writeln!(profile, "(allow system-socket").unwrap();
+        writeln!(
+            profile,
+            "  (require-all (socket-domain AF_SYSTEM) (socket-protocol 2))"
+        )
+        .unwrap();
+        writeln!(profile, "  (socket-domain AF_ROUTE))").unwrap();
+        writeln!(profile).unwrap();
+
+        // File reads for network stack (from Apple's system-network).
+        writeln!(profile, "; Network stack files").unwrap();
+        writeln!(
+            profile,
+            "(allow file-read* (literal \"/Library/Preferences/com.apple.networkd.plist\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow file-read* (literal \"/private/var/db/nsurlstoraged/dafsaData.bin\"))"
+        )
+        .unwrap();
+        writeln!(profile).unwrap();
+    } else if data.control_socket.is_some() || data.llm_socket.is_some() {
+        writeln!(
+            profile,
+            "; Unix sockets (strict mode — scoped to configured paths)"
+        )
+        .unwrap();
         if let Some(ref s) = data.control_socket {
+            writeln!(
+                profile,
+                "(allow network-outbound (remote unix-socket (path-literal \"{s}\")))"
+            )
+            .unwrap();
             writeln!(profile, "(allow file-read* (literal \"{s}\"))").unwrap();
             writeln!(profile, "(allow file-write* (literal \"{s}\"))").unwrap();
         }
         if let Some(ref s) = data.llm_socket {
+            writeln!(
+                profile,
+                "(allow network-outbound (remote unix-socket (path-literal \"{s}\")))"
+            )
+            .unwrap();
+            writeln!(profile, "(allow file-read* (literal \"{s}\"))").unwrap();
+            writeln!(profile, "(allow file-write* (literal \"{s}\"))").unwrap();
+        }
+        writeln!(profile).unwrap();
+    }
+
+    // Socket permissions in network mode (scoped to configured paths).
+    if data.allow_network && (data.control_socket.is_some() || data.llm_socket.is_some()) {
+        if let Some(ref s) = data.control_socket {
+            writeln!(
+                profile,
+                "(allow network-outbound (remote unix-socket (path-literal \"{s}\")))"
+            )
+            .unwrap();
+            writeln!(profile, "(allow file-read* (literal \"{s}\"))").unwrap();
+            writeln!(profile, "(allow file-write* (literal \"{s}\"))").unwrap();
+        }
+        if let Some(ref s) = data.llm_socket {
+            writeln!(
+                profile,
+                "(allow network-outbound (remote unix-socket (path-literal \"{s}\")))"
+            )
+            .unwrap();
             writeln!(profile, "(allow file-read* (literal \"{s}\"))").unwrap();
             writeln!(profile, "(allow file-write* (literal \"{s}\"))").unwrap();
         }
@@ -211,6 +309,67 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
         "(allow mach-lookup (global-name \"com.apple.system.notification_center\"))"
     )
     .unwrap();
+
+    if data.allow_network {
+        // Apple system-network Mach services (from system.sb).
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.dnssd.service\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.nehelper\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.nesessionmanager\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.networkd\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.symptomsd\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.usymptomsd\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.SystemConfiguration.SCNetworkReachability\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.cfnetwork.cfnetworkagent\"))"
+        )
+        .unwrap();
+        // TLS certificate validation.
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.trustd\"))"
+        )
+        .unwrap();
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.trustd.agent\"))"
+        )
+        .unwrap();
+        // DNS and network configuration.
+        writeln!(
+            profile,
+            "(allow mach-lookup (global-name \"com.apple.SystemConfiguration.configd\"))"
+        )
+        .unwrap();
+    }
     writeln!(profile).unwrap();
 
     // POSIX shared memory (read-only).
@@ -254,12 +413,18 @@ mod tests {
         assert!(validate_profile_path("/opt/homebrew/opt/python@3.14/bin/python3.14").is_ok());
         // Dots.
         assert!(validate_profile_path("/usr/lib/libfoo.1.2.dylib").is_ok());
+        // + in C++ library paths.
+        assert!(validate_profile_path("/usr/lib/libc++.1.dylib").is_ok());
+        assert!(validate_profile_path("/opt/homebrew/Cellar/llvm/17/lib/c++").is_ok());
     }
 
     #[test]
     fn test_validate_profile_path_invalid() {
         // Empty.
         assert!(validate_profile_path("").is_err());
+        // Path traversal.
+        assert!(validate_profile_path("/tmp/../etc/passwd").is_err());
+        assert!(validate_profile_path("/nonexistent/../etc").is_err());
         // Double quote (profile injection).
         assert!(validate_profile_path("/tmp/foo\"bar").is_err());
         // Parentheses (Seatbelt syntax).
@@ -293,6 +458,7 @@ mod tests {
             exec_paths: vec!["/usr/local/bin".into()],
             control_socket: Some("/tmp/sock/control.sock".into()),
             llm_socket: Some("/tmp/sock/llm.sock".into()),
+            allow_network: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();
@@ -315,7 +481,7 @@ mod tests {
 
         // Verify /etc paths use canonical /private/etc prefix.
         assert!(content.contains("(allow file-read* (literal \"/private/etc/hosts\"))"));
-        assert!(content.contains("(allow file-read* (subpath \"/private/etc/ssl/certs\"))"));
+        assert!(content.contains("(allow file-read* (subpath \"/private/etc/ssl\"))"));
 
         // Verify /System is a subpath (covers /System/Library and
         // /System/Cryptexes).
@@ -328,13 +494,29 @@ mod tests {
         assert!(content.contains("(allow file-read* (subpath \"/tmp/work\"))"));
         assert!(content.contains("(allow file-write* (subpath \"/tmp/work\"))"));
 
-        // Verify socket paths.
+        // Verify scoped unix socket paths (strict mode).
+        assert!(content.contains(
+            "(allow network-outbound (remote unix-socket (path-literal \"/tmp/sock/control.sock\")))"
+        ));
+        assert!(content.contains(
+            "(allow network-outbound (remote unix-socket (path-literal \"/tmp/sock/llm.sock\")))"
+        ));
         assert!(content.contains("(allow file-read* (literal \"/tmp/sock/control.sock\"))"));
         assert!(content.contains("(allow file-write* (literal \"/tmp/sock/llm.sock\"))"));
 
         // Verify exec paths — explicit + auto-included from write paths.
         assert!(content.contains("(allow process-exec (subpath \"/usr/local/bin\"))"));
         assert!(content.contains("(allow process-exec (subpath \"/tmp/work\"))"));
+
+        // Verify NO network rules in strict mode.
+        assert!(
+            !content.contains("network-outbound (remote tcp)"),
+            "strict mode must not allow TCP outbound"
+        );
+        assert!(
+            !content.contains("com.apple.dnssd.service"),
+            "strict mode must not allow network Mach services"
+        );
 
         // Verify file permissions.
         #[cfg(unix)]
@@ -360,10 +542,80 @@ mod tests {
             exec_paths: vec![],
             control_socket: None,
             llm_socket: None,
+            allow_network: false,
         };
 
         let result = generate_profile(&dir, &data);
         assert!(result.is_err(), "injection path should be rejected");
+
+        // Cleanup.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_generate_profile_with_network() {
+        let dir = std::env::temp_dir().join("arapuca-test-profile-net");
+        let _ = std::fs::create_dir_all(&dir);
+
+        let data = ProfileData {
+            read_paths: vec!["/home/user/src".into()],
+            write_paths: vec!["/tmp/work".into()],
+            exec_paths: vec![],
+            control_socket: None,
+            llm_socket: None,
+            allow_network: true,
+        };
+
+        let path = generate_profile(&dir, &data).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+
+        // File metadata scoped to system paths (not global).
+        assert!(content.contains("(allow file-read-metadata (subpath \"/private/var\"))"));
+        assert!(content.contains("(allow file-read-metadata (subpath \"/usr\"))"));
+        assert!(
+            !content.contains("file-read-metadata (subpath \"/\")"),
+            "file-read-metadata must not scope to root"
+        );
+
+        // TCP outbound.
+        assert!(content.contains("(allow network-outbound (remote tcp))"));
+
+        // mDNSResponder — scoped, not blanket unix.
+        assert!(content.contains("mDNSResponder"));
+        assert!(
+            !content.contains("(allow network-outbound (remote unix))"),
+            "unix socket outbound must be scoped, not blanket"
+        );
+
+        // Kernel control sockets.
+        assert!(content.contains("com.apple.netsrc"));
+        assert!(content.contains("com.apple.network.statistics"));
+
+        // System sockets.
+        assert!(content.contains("AF_SYSTEM"));
+        assert!(content.contains("AF_ROUTE"));
+
+        // Apple system-network Mach services.
+        assert!(content.contains("com.apple.dnssd.service"));
+        assert!(content.contains("com.apple.networkd"));
+        assert!(content.contains("com.apple.SystemConfiguration.SCNetworkReachability"));
+        assert!(content.contains("com.apple.cfnetwork.cfnetworkagent"));
+
+        // TLS Mach services.
+        assert!(content.contains("com.apple.trustd"));
+        assert!(content.contains("com.apple.trustd.agent"));
+
+        // DNS/network configuration.
+        assert!(content.contains("com.apple.SystemConfiguration.configd"));
+
+        // Network stack files.
+        assert!(content.contains("com.apple.networkd.plist"));
+
+        // deny-default still present.
+        assert!(content.contains("(deny default)"));
+
+        // Base Mach services still present.
+        assert!(content.contains("com.apple.system.logger"));
 
         // Cleanup.
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -111,6 +111,7 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
         "/Library/Frameworks",
         "/System",
         "/dev",
+        "/private/var/select",
     ] {
         writeln!(profile, "(allow file-read* (subpath \"{sys_path}\"))").unwrap();
     }
@@ -308,6 +309,9 @@ mod tests {
         assert!(content.contains("(allow file-read* (literal \"/etc\"))"));
         assert!(content.contains("(allow file-read* (literal \"/private\"))"));
         assert!(content.contains("(allow file-read* (literal \"/private/var\"))"));
+
+        // Verify /private/var/select is readable (shell resolution).
+        assert!(content.contains("(allow file-read* (subpath \"/private/var/select\"))"));
 
         // Verify /etc paths use canonical /private/etc prefix.
         assert!(content.contains("(allow file-read* (literal \"/private/etc/hosts\"))"));

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -106,7 +106,7 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
     // /etc is a symlink to /private/etc — it must be readable for
     // processes that open /etc/hosts, /etc/resolv.conf, etc.
     writeln!(profile, "; Ancestor directories for path traversal").unwrap();
-    for ancestor in &["/opt", "/etc", "/private", "/private/var"] {
+    for ancestor in &["/opt", "/etc", "/Users", "/private", "/private/var"] {
         writeln!(profile, "(allow file-read* (literal \"{ancestor}\"))").unwrap();
     }
     writeln!(profile).unwrap();
@@ -123,6 +123,7 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
         "/System",
         "/dev",
         "/private/var/select",
+        "/private/var/db/timezone",
     ] {
         writeln!(profile, "(allow file-read* (subpath \"{sys_path}\"))").unwrap();
     }
@@ -474,6 +475,7 @@ mod tests {
         assert!(content.contains("(allow file-read* (literal \"/opt\"))"));
         assert!(content.contains("(allow file-read* (literal \"/etc\"))"));
         assert!(content.contains("(allow file-read* (literal \"/private\"))"));
+        assert!(content.contains("(allow file-read* (literal \"/Users\"))"));
         assert!(content.contains("(allow file-read* (literal \"/private/var\"))"));
 
         // Verify /private/var/select is readable (shell resolution).

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -157,6 +157,7 @@ impl Sandbox for Darwin {
 
         let wrapper = Self::wrapper_path();
         let use_wrapper = wrapper.is_some();
+        let allow_network = cfg.profile.seccomp_profile == crate::SeccompProfile::Baseline;
 
         let audit_ctx = cfg
             .audit_sink
@@ -202,10 +203,15 @@ impl Sandbox for Darwin {
                 })?;
             }
 
+            let seatbelt_detail = if allow_network {
+                "network=allowed"
+            } else {
+                "network=denied"
+            };
             ctx.emit(AuditEvent::LayerApplied {
                 timestamp: ctx.timestamp(),
                 layer: SandboxLayer::Seatbelt,
-                detail: None,
+                detail: Some(crate::audit::LayerDetail::Other(seatbelt_detail.into())),
             })?;
             ctx.emit(AuditEvent::LayerApplied {
                 timestamp: ctx.timestamp(),
@@ -236,13 +242,21 @@ impl Sandbox for Darwin {
         let tmp_dir = tmp_guard.path().to_path_buf();
 
         // Helper: canonicalize a path for Seatbelt profile embedding.
-        // Falls back to the original if canonicalization fails (path
-        // may not exist yet, e.g. socket files).
+        // For files that don't exist yet (e.g. socket files),
+        // canonicalize the parent directory and re-attach the filename.
+        // This is critical on macOS where /tmp → /private/tmp and
+        // /var → /private/var — Seatbelt matches kernel-resolved paths,
+        // so profile paths must be canonical.
         let canon = |p: &std::path::Path| -> String {
-            std::fs::canonicalize(p)
-                .unwrap_or_else(|_| p.to_path_buf())
-                .to_string_lossy()
-                .into_owned()
+            if let Ok(c) = std::fs::canonicalize(p) {
+                return c.to_string_lossy().into_owned();
+            }
+            if let (Some(parent), Some(name)) = (p.parent(), p.file_name()) {
+                if let Ok(cp) = std::fs::canonicalize(parent) {
+                    return cp.join(name).to_string_lossy().into_owned();
+                }
+            }
+            p.to_string_lossy().into_owned()
         };
 
         // Build profile data from config. All paths must be
@@ -295,6 +309,7 @@ impl Sandbox for Darwin {
             exec_paths,
             control_socket,
             llm_socket,
+            allow_network,
         };
 
         // Generate the Seatbelt profile.

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -152,8 +152,13 @@ impl Darwin {
 
 impl Sandbox for Darwin {
     fn launch(&self, cfg: &Config, cmd: &str, args: &[&str]) -> crate::Result<Process> {
-        // Validate task ID.
+        // Validate task ID and work directory.
         crate::sanitize_task_id(&cfg.task_id)?;
+        crate::validate_work_dir(
+            &cfg.work_dir,
+            &cfg.profile.read_paths,
+            &cfg.profile.write_paths,
+        )?;
 
         let wrapper = Self::wrapper_path();
         let use_wrapper = wrapper.is_some();

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -54,6 +54,13 @@ impl Sandbox for Linux {
         crate::reject_cgroup_paths(&cfg.profile.read_paths)?;
         crate::reject_cgroup_paths(&cfg.profile.write_paths)?;
 
+        // Defense-in-depth: validate work_dir is within mounted paths.
+        crate::validate_work_dir(
+            &cfg.work_dir,
+            &cfg.profile.read_paths,
+            &cfg.profile.write_paths,
+        )?;
+
         let tmp_guard = crate::env::TmpDirGuard::new(crate::env::make_tmp_dir(&cfg.task_id)?);
 
         let audit_ctx = cfg

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -26,8 +26,13 @@ impl Sandbox for Other {
             ));
         }
 
-        // Validate task ID.
+        // Validate task ID and work directory.
         crate::sanitize_task_id(&cfg.task_id)?;
+        crate::validate_work_dir(
+            &cfg.work_dir,
+            &cfg.profile.read_paths,
+            &cfg.profile.write_paths,
+        )?;
 
         let tmp_guard = crate::env::TmpDirGuard::new(crate::env::make_tmp_dir(&cfg.task_id)?);
 

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -26,6 +26,9 @@ impl Sandbox for Other {
             ));
         }
 
+        // Validate task ID.
+        crate::sanitize_task_id(&cfg.task_id)?;
+
         let tmp_guard = crate::env::TmpDirGuard::new(crate::env::make_tmp_dir(&cfg.task_id)?);
 
         let audit_ctx = cfg

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -97,6 +97,55 @@ pub fn validate_guest_permissions(perms: &str) -> crate::Result<()> {
     Ok(())
 }
 
+/// Validate the working directory for the sandboxed process.
+///
+/// Defense-in-depth: ensures `work_dir` (when set) is absolute, exists as a
+/// directory, and falls within a configured read or write path. Landlock
+/// enforces filesystem access at runtime, but rejecting invalid `work_dir`
+/// early produces clear errors instead of confusing EACCES failures.
+///
+/// Both `work_dir` and mount paths are canonicalized to handle symlinks.
+#[cfg(unix)]
+pub fn validate_work_dir(
+    work_dir: &Option<std::path::PathBuf>,
+    read_paths: &[std::path::PathBuf],
+    write_paths: &[std::path::PathBuf],
+) -> crate::Result<()> {
+    let dir = match work_dir {
+        Some(d) => d,
+        None => return Ok(()),
+    };
+    if !dir.is_absolute() {
+        return Err(Error::Validation(format!(
+            "work_dir must be absolute: {}",
+            dir.display()
+        )));
+    }
+    let canonical = dir.canonicalize().map_err(|e| {
+        Error::Validation(format!(
+            "work_dir cannot be resolved: {}: {e}",
+            dir.display()
+        ))
+    })?;
+    if !canonical.is_dir() {
+        return Err(Error::Validation(format!(
+            "work_dir is not a directory: {}",
+            canonical.display()
+        )));
+    }
+    let in_mounts = read_paths.iter().chain(write_paths.iter()).any(|p| {
+        let resolved = p.canonicalize().unwrap_or_else(|_| p.clone());
+        canonical.starts_with(&resolved)
+    });
+    if !in_mounts {
+        return Err(Error::Validation(format!(
+            "work_dir must be within a mounted path: {}",
+            canonical.display()
+        )));
+    }
+    Ok(())
+}
+
 /// Reject paths that resolve to `/sys/fs/cgroup`.
 ///
 /// Defense-in-depth: prevents a sandboxed process from modifying its own
@@ -386,5 +435,68 @@ mod tests {
     fn guest_file_content_one_over_rejected() {
         let content = "a".repeat(MAX_GUEST_FILE_SIZE + 1);
         assert!(validate_guest_file_content(&content).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_none_ok() {
+        assert!(validate_work_dir(&None, &[], &[]).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_relative_rejected() {
+        let dir = Some(PathBuf::from("relative/path"));
+        assert!(validate_work_dir(&dir, &[], &[]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_nonexistent_rejected() {
+        let dir = Some(PathBuf::from("/nonexistent-arapuca-test-path"));
+        assert!(validate_work_dir(&dir, &[], &[]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_file_not_dir_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("not-a-dir");
+        std::fs::write(&file, "").unwrap();
+        let dir = Some(file);
+        let mounts = vec![tmp.path().to_path_buf()];
+        assert!(validate_work_dir(&dir, &mounts, &[]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_outside_mounts_rejected() {
+        let dir = Some(PathBuf::from("/tmp"));
+        let mounts = vec![PathBuf::from("/usr")];
+        assert!(validate_work_dir(&dir, &mounts, &[]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_in_read_paths_ok() {
+        let dir = Some(PathBuf::from("/tmp"));
+        let read = vec![PathBuf::from("/tmp")];
+        assert!(validate_work_dir(&dir, &read, &[]).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_in_write_paths_ok() {
+        let dir = Some(PathBuf::from("/tmp"));
+        let write = vec![PathBuf::from("/tmp")];
+        assert!(validate_work_dir(&dir, &[], &write).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn work_dir_subdir_of_mount_ok() {
+        let dir = Some(std::env::temp_dir());
+        let mounts = vec![PathBuf::from("/")];
+        assert!(validate_work_dir(&dir, &mounts, &[]).is_ok());
     }
 }

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -794,18 +794,19 @@ fn wait_with_timeout(
 #[test]
 fn cwd_sets_working_directory() {
     let dir = tempfile::tempdir().unwrap();
-    let dir_str = dir.path().to_str().unwrap();
-    let vol = format!("{dir_str}:ro");
+    let canonical = dir.path().canonicalize().unwrap();
+    let canonical_str = canonical.to_str().unwrap();
+    let vol = format!("{canonical_str}:ro");
 
     let output = Command::new(arapuca_bin())
-        .args(["run", "--cwd", dir_str, "-v", &vol, "--", "/bin/pwd"])
+        .args(["run", "--cwd", canonical_str, "-v", &vol, "--", "/bin/pwd"])
         .output()
         .unwrap();
 
     assert!(output.status.success(), "pwd should succeed with --cwd");
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        dir_str,
+        canonical_str,
         "working directory should match --cwd"
     );
 }
@@ -863,7 +864,8 @@ fn cwd_symlink_outside_mount_rejected() {
     let link = dir.path().join("escape");
     std::os::unix::fs::symlink("/etc", &link).unwrap();
 
-    let dir_str = dir.path().to_str().unwrap();
+    let canonical = dir.path().canonicalize().unwrap();
+    let dir_str = canonical.to_str().unwrap();
     let vol = format!("{dir_str}:ro");
     let link_str = link.to_str().unwrap();
 
@@ -884,7 +886,8 @@ fn cwd_file_not_directory_rejected() {
     let file = dir.path().join("not-a-dir.txt");
     std::fs::write(&file, "").unwrap();
 
-    let dir_str = dir.path().to_str().unwrap();
+    let canonical = dir.path().canonicalize().unwrap();
+    let dir_str = canonical.to_str().unwrap();
     let vol = format!("{dir_str}:ro");
     let file_str = file.to_str().unwrap();
 
@@ -901,6 +904,9 @@ fn cwd_file_not_directory_rejected() {
 
 #[test]
 fn cwd_with_default_paths() {
+    let expected = std::path::PathBuf::from("/tmp").canonicalize().unwrap();
+    let expected_str = expected.to_str().unwrap();
+
     let output = Command::new(arapuca_bin())
         .args(["run", "--cwd", "/tmp", "--", "/bin/pwd"])
         .output()
@@ -912,8 +918,8 @@ fn cwd_with_default_paths() {
     );
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),
-        "/tmp",
-        "working directory should be /tmp"
+        expected_str,
+        "working directory should be /tmp (canonicalized)"
     );
 }
 
@@ -923,8 +929,10 @@ fn cwd_subdirectory_of_mount_accepted() {
     let sub = dir.path().join("child");
     std::fs::create_dir(&sub).unwrap();
 
-    let dir_str = dir.path().to_str().unwrap();
-    let sub_str = sub.to_str().unwrap();
+    let canonical_dir = dir.path().canonicalize().unwrap();
+    let canonical_sub = sub.canonicalize().unwrap();
+    let dir_str = canonical_dir.to_str().unwrap();
+    let sub_str = canonical_sub.to_str().unwrap();
     let vol = format!("{dir_str}:ro");
 
     let output = Command::new(arapuca_bin())
@@ -944,9 +952,23 @@ fn cwd_subdirectory_of_mount_accepted() {
 }
 
 #[test]
+fn cwd_path_traversal_resolved() {
+    let status = Command::new(arapuca_bin())
+        .args(["run", "--cwd", "/tmp/../etc", "--", "/bin/true"])
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(125),
+        "--cwd with path traversal should resolve and be rejected"
+    );
+}
+
+#[test]
 fn cwd_with_write_mount_allows_writing() {
     let dir = tempfile::tempdir().unwrap();
-    let dir_str = dir.path().to_str().unwrap();
+    let canonical = dir.path().canonicalize().unwrap();
+    let dir_str = canonical.to_str().unwrap();
 
     let output = Command::new(arapuca_bin())
         .args([


### PR DESCRIPTION
Enables network-capable programs to run inside arapuca's macOS sandbox by adding a baseline network mode to the Seatbelt profile (TCP outbound, DNS via mDNSResponder, Apple system-network Mach services). Also hardens the profile: restricts /dev to specific devices, scopes file-read-metadata and unix socket rules, rejects .. traversal, and adds validate_work_dir parity across platforms.