### PR TITLE
rlimit: add RLIMIT_NOFILE enforcement

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -192,6 +192,14 @@ void arapuca_profile_set_max_pids(struct arapuca_ArapucaProfile *profile, uint32
 void arapuca_profile_set_max_file_size_mb(struct arapuca_ArapucaProfile *profile, uint64_t mb);
 
 /**
+ * Set maximum open file descriptors (RLIMIT_NOFILE).
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_max_open_files(struct arapuca_ArapucaProfile *profile, uint64_t n);
+
+/**
  * Enable/disable network namespace isolation.
  *
  * # Safety

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -98,6 +98,7 @@ pub enum AuditEvent {
         cpu_pct: u32,
         max_pids: u32,
         max_file_size_mb: u64,
+        max_open_files: u64,
         allow_exec: bool,
     },
 

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -14,6 +14,7 @@
 //!                         automatically — per-UID system-wide limit)
 //!   ARAPUCA_RLIMIT_CPU:   max CPU seconds (0 = no limit)
 //!   ARAPUCA_RLIMIT_FSIZE: max file size in bytes (0 = no limit)
+//!   ARAPUCA_RLIMIT_NOFILE: max open file descriptors (0 = no limit)
 //!
 //! Usage: arapuca -- command [args...]
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -331,6 +331,12 @@ pub fn wrapper_env(profile: &crate::Profile) -> Vec<(String, String)> {
             (profile.max_file_size_mb * 1024 * 1024).to_string(),
         ));
     }
+    if profile.max_open_files > 0 {
+        env.push((
+            "ARAPUCA_RLIMIT_NOFILE".into(),
+            profile.max_open_files.to_string(),
+        ));
+    }
     // Always emit — never rely on absence encoding Strict.
     // Linux::launch() calls env_clear() so ambient vars don't leak,
     // but defense-in-depth: explicit is better than implicit.
@@ -735,6 +741,7 @@ mod tests {
             max_memory_mb: 256,
             max_pids: 100,
             max_file_size_mb: 512,
+            max_open_files: 1024,
             read_paths: vec![PathBuf::from("/usr")],
             ..Default::default()
         };
@@ -744,6 +751,7 @@ mod tests {
 
         let fsize_bytes = (512u64 * 1024 * 1024).to_string();
         assert_eq!(map.get("ARAPUCA_RLIMIT_FSIZE"), Some(&fsize_bytes.as_str()));
+        assert_eq!(map.get("ARAPUCA_RLIMIT_NOFILE"), Some(&"1024"));
         assert_eq!(map.get("ARAPUCA_READ_PATHS"), Some(&"/usr"));
         assert!(!map.contains_key("ARAPUCA_RLIMIT_NPROC"));
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -208,6 +208,19 @@ pub unsafe extern "C" fn arapuca_profile_set_max_file_size_mb(
     }
 }
 
+/// Set maximum open file descriptors (RLIMIT_NOFILE).
+///
+/// # Safety
+/// `profile` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_max_open_files(profile: *mut ArapucaProfile, n: u64) {
+    if let Some(profile) = unsafe { profile.as_mut() } {
+        if let Some(inner) = profile.inner.as_mut() {
+            inner.max_open_files = n;
+        }
+    }
+}
+
 /// Enable/disable network namespace isolation.
 ///
 /// # Safety

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -559,6 +559,7 @@ impl Sandbox for Linux {
                 cpu_pct: cfg.profile.max_cpu_pct,
                 max_pids: cfg.profile.max_pids,
                 max_file_size_mb: cfg.profile.max_file_size_mb,
+                max_open_files: cfg.profile.max_open_files,
                 allow_exec: cfg.profile.allow_exec,
             })?;
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -113,6 +113,8 @@ pub struct Profile {
     pub max_pids: u32,
     /// Maximum file size in MB via RLIMIT_FSIZE (0 = no limit).
     pub max_file_size_mb: u64,
+    /// Maximum open file descriptors via RLIMIT_NOFILE (0 = no limit).
+    pub max_open_files: u64,
     /// Whether execve is permitted (for git, test runners, etc.).
     pub allow_exec: bool,
     /// Use CLONE_NEWNET for network namespace isolation (Linux only).

--- a/src/rlimit.rs
+++ b/src/rlimit.rs
@@ -3,6 +3,7 @@
 //! Sets hard resource limits on the sandboxed process:
 //! - RLIMIT_CPU: CPU time in seconds
 //! - RLIMIT_FSIZE: maximum file size
+//! - RLIMIT_NOFILE: maximum open file descriptors
 //!
 //! Memory and PID limits are enforced via cgroups v2 (`memory.max`,
 //! `pids.max`), not RLIMIT_AS/RLIMIT_NPROC. Both rlimits are
@@ -18,8 +19,8 @@ use crate::{Error, Profile};
 /// Apply resource limits from the profile to the current process.
 ///
 /// Sets RLIMIT_CORE=0 unconditionally (prevents core dumps from
-/// leaking secrets), and RLIMIT_FSIZE if configured. Memory and PID
-/// limits are enforced via
+/// leaking secrets), plus RLIMIT_FSIZE and RLIMIT_NOFILE when
+/// configured. Memory and PID limits are enforced via
 /// cgroups v2 (`memory.max`, `pids.max`), not RLIMIT_AS/RLIMIT_NPROC.
 /// Both are system-wide per-UID limits that break sandboxed workloads:
 /// RLIMIT_AS kills Go/JVM/.NET at startup, and RLIMIT_NPROC fails
@@ -39,13 +40,17 @@ pub fn apply(profile: &Profile) -> crate::Result<()> {
         let bytes = profile.max_file_size_mb * 1024 * 1024;
         set_rlimit(libc::RLIMIT_FSIZE, bytes, "RLIMIT_FSIZE")?;
     }
+    if profile.max_open_files > 0 {
+        set_rlimit(libc::RLIMIT_NOFILE, profile.max_open_files, "RLIMIT_NOFILE")?;
+    }
     Ok(())
 }
 
 /// Apply resource limits parsed from environment variables.
 ///
 /// Used by the binary. Reads `ARAPUCA_RLIMIT_AS`, `ARAPUCA_RLIMIT_NPROC`,
-/// `ARAPUCA_RLIMIT_CPU`, `ARAPUCA_RLIMIT_FSIZE` from the environment.
+/// `ARAPUCA_RLIMIT_CPU`, `ARAPUCA_RLIMIT_FSIZE`, and `ARAPUCA_RLIMIT_NOFILE`
+/// from the environment.
 pub fn apply_from_env() -> crate::Result<()> {
     set_rlimit(libc::RLIMIT_CORE, 0, "RLIMIT_CORE")?;
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_AS")? {
@@ -59,6 +64,9 @@ pub fn apply_from_env() -> crate::Result<()> {
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_FSIZE")? {
         set_rlimit(libc::RLIMIT_FSIZE, v, "RLIMIT_FSIZE")?;
+    }
+    if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_NOFILE")? {
+        set_rlimit(libc::RLIMIT_NOFILE, v, "RLIMIT_NOFILE")?;
     }
     Ok(())
 }


### PR DESCRIPTION
A sandboxed process inherits the parent's fd limit (typically 1024 soft / 1M hard) and can exhaust file descriptors via tmpdir files or AF_UNIX sockets. Add max_open_files to Profile and apply RLIMIT_NOFILE when configured, following the existing RLIMIT_FSIZE pattern across env, audit, and FFI layers.