### PR TITLE
bridge: add DNS query capture and NetworkBlocked audit events

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -208,6 +208,18 @@ void arapuca_profile_set_max_open_files(struct arapuca_ArapucaProfile *profile, 
 void arapuca_profile_set_netns(struct arapuca_ArapucaProfile *profile, bool enabled);
 
 /**
+ * Enable DNS query capture inside the network namespace.
+ *
+ * When enabled alongside netns, the bridge child intercepts DNS
+ * queries and emits NetworkBlocked audit events. Requires the
+ * serde feature and the wrapper binary with filesystem paths.
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_dns_capture(struct arapuca_ArapucaProfile *profile, bool enabled);
+
+/**
  * Set micro-VM isolation on a profile with a distro image source.
  *
  * After this call, launching with this profile creates a VM instead

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -184,6 +184,24 @@ pub enum AuditEvent {
         dacls_restored: Option<bool>,
         container_deleted: Option<bool>,
     },
+
+    /// A sandboxed process attempted a blocked network connection.
+    ///
+    /// On Linux, this captures DNS queries intercepted by the bridge's
+    /// DNS server. Direct IP connections (no DNS involved) are blocked
+    /// by the network namespace but do NOT generate this event — their
+    /// capture requires seccomp-unotify (future work).
+    ///
+    /// On macOS, this captures Seatbelt network-outbound denials
+    /// parsed from the unified log after the process exits.
+    #[non_exhaustive]
+    NetworkBlocked {
+        timestamp: AuditTimestamp,
+        pid: u32,
+        destination: String,
+        protocol: String,
+        detail: Option<String>,
+    },
 }
 
 /// Current schema version. Incremented only for breaking changes.
@@ -221,6 +239,7 @@ pub enum SandboxLayer {
     MitigationPolicy,
     DaclGrant,
     ProcessSpawn,
+    DnsCapture,
 }
 
 /// Structured detail for a successfully applied layer.
@@ -244,6 +263,9 @@ pub enum LayerDetail {
         image_path: String,
         cpus: u32,
         mem_mb: u32,
+    },
+    DnsCapture {
+        port: u16,
     },
     Other(String),
 }
@@ -584,5 +606,51 @@ mod tests {
     #[test]
     fn schema_version_is_one() {
         assert_eq!(SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn network_blocked_event_can_be_constructed() {
+        let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+        let sink: Arc<dyn AuditSink> = Arc::clone(&vec_sink) as Arc<dyn AuditSink>;
+        let ctx = AuditContext::new(sink, AuditVerbosity::Standard);
+        let event = AuditEvent::NetworkBlocked {
+            timestamp: ctx.timestamp(),
+            pid: 1234,
+            destination: "evil.com".into(),
+            protocol: "dns".into(),
+            detail: Some("A".into()),
+        };
+        ctx.emit(event).unwrap();
+        let events = vec_sink.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn network_blocked_event_serializes() {
+        let event = AuditEvent::NetworkBlocked {
+            timestamp: AuditTimestamp(42),
+            pid: 1234,
+            destination: "evil.com".into(),
+            protocol: "dns".into(),
+            detail: Some("A".into()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event_type\":\"NetworkBlocked\""));
+        assert!(json.contains("\"destination\":\"evil.com\""));
+        assert!(json.contains("\"protocol\":\"dns\""));
+        assert!(json.contains("\"detail\":\"A\""));
+    }
+
+    #[test]
+    fn dns_capture_layer_detail() {
+        let detail = LayerDetail::DnsCapture { port: 53 };
+        assert!(matches!(detail, LayerDetail::DnsCapture { port: 53 }));
+    }
+
+    #[test]
+    fn dns_capture_sandbox_layer_exists() {
+        let layer = SandboxLayer::DnsCapture;
+        assert_eq!(layer, SandboxLayer::DnsCapture);
     }
 }

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -193,7 +193,12 @@ fn main() {
         // Activated when ARAPUCA_PROXY_BRIDGE=<port>:<uds_path> is set.
         match arapuca::bridge::parse_bridge_env() {
             Ok(Some((port, uds_path))) => {
-                let bridge_port = match arapuca::bridge::fork_bridge(port, &uds_path) {
+                let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+                    .ok()
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .filter(|&fd| fd >= 0);
+                let bridge_port = match arapuca::bridge::fork_bridge(port, &uds_path, dns_audit_fd)
+                {
                     Ok(p) => p,
                     Err(e) => {
                         audit_layer(audit_fd, "ProxyBridge", false, Some(&e.to_string()));
@@ -269,10 +274,17 @@ fn main() {
         audit_layer(audit_fd, "Pdeathsig", true, None);
     }
 
-    // Close audit FD before exec — the target command must not inherit it.
+    // Close audit FDs before exec — the target command must not inherit them.
     #[cfg(unix)]
     if let Some(fd) = audit_fd {
         // SAFETY: fd is a valid file descriptor from ARAPUCA_AUDIT_FD.
+        unsafe { libc::close(fd) };
+    }
+    #[cfg(unix)]
+    if let Some(fd) = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+        .ok()
+        .and_then(|s| s.parse::<i32>().ok())
+    {
         unsafe { libc::close(fd) };
     }
 

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -381,6 +381,7 @@ fn run_subcommand(args: &[String]) {
     let mut tty = false;
     #[cfg(target_os = "linux")]
     let mut allowed_hosts: Vec<arapuca::bridge::AllowedHost> = Vec::new();
+    let mut deny_network = false;
 
     // Find -- separator.
     let sep_pos = args.iter().position(|a| a == "--");
@@ -403,6 +404,9 @@ fn run_subcommand(args: &[String]) {
             eprintln!("  --pids N           max number of PIDs");
             eprintln!("  --task-id NAME     identifier for cgroup and audit");
             eprintln!("  --allow-host H:P   allow HTTPS to host:port or *.domain:port");
+            eprintln!(
+                "  --deny-network     block all network; capture DNS queries as audit events"
+            );
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  -t, --tty          allocate a PTY for interactive programs");
             if sep_pos.is_none() && !args.is_empty() {
@@ -560,6 +564,14 @@ fn run_subcommand(args: &[String]) {
                     std::process::exit(125);
                 }
             }
+            "--deny-network" => {
+                deny_network = true;
+                #[cfg(not(target_os = "linux"))]
+                eprintln!(
+                    "arapuca run: --deny-network: DNS capture is Linux-only; \
+                     network denial on this platform is handled by the native sandbox"
+                );
+            }
             #[cfg(unix)]
             "-t" | "--tty" => {
                 tty = true;
@@ -680,7 +692,8 @@ fn run_subcommand(args: &[String]) {
         max_cpu_pct: cpus.unwrap_or(0),
         max_pids: pids.unwrap_or(0),
         allow_exec: true,
-        use_netns: connect_proxy_socket.is_some(),
+        use_netns: connect_proxy_socket.is_some() || deny_network,
+        dns_capture: deny_network,
         seccomp_profile,
         ..Default::default()
     };

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -640,6 +640,13 @@ fn run_subcommand(args: &[String]) {
         i += 1;
     }
 
+    // ── Flag validation ────────────────────────────────────────
+    #[cfg(target_os = "linux")]
+    if deny_network && !allowed_hosts.is_empty() {
+        eprintln!("arapuca run: --deny-network and --allow-host are mutually exclusive");
+        std::process::exit(125);
+    }
+
     // ── CONNECT proxy for --allow-host ────────────────────────
     #[cfg(target_os = "linux")]
     let (connect_proxy_socket, connect_proxy_pid, connect_proxy_pidfd) =

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -204,15 +204,15 @@ fn main() {
                     .ok()
                     .and_then(|s| s.parse::<i32>().ok())
                     .filter(|&fd| fd >= 0);
-                let bridge_port = match arapuca::bridge::fork_bridge(port, &uds_path, dns_audit_fd)
-                {
-                    Ok(p) => p,
-                    Err(e) => {
-                        audit_layer(audit_fd, "ProxyBridge", false, Some(&e.to_string()));
-                        eprintln!("arapuca: bridge: {e}");
-                        std::process::exit(1);
-                    }
-                };
+                let bridge_port =
+                    match arapuca::bridge::fork_bridge(port, Some(&uds_path), dns_audit_fd) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            audit_layer(audit_fd, "ProxyBridge", false, Some(&e.to_string()));
+                            eprintln!("arapuca: bridge: {e}");
+                            std::process::exit(1);
+                        }
+                    };
                 let proxy = format!("http://127.0.0.1:{bridge_port}");
                 // SAFETY: single-threaded at this point (between
                 // Landlock apply and seccomp apply, no threads spawned).
@@ -224,7 +224,26 @@ fn main() {
                 }
                 audit_layer(audit_fd, "ProxyBridge", true, None);
             }
-            Ok(None) => {}
+            Ok(None) => {
+                // DNS-only bridge: fork bridge for DNS capture without
+                // TCP relay when ARAPUCA_DNS_AUDIT_FD is set.
+                let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+                    .ok()
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .filter(|&fd| fd >= 0);
+                if let Some(dns_fd) = dns_audit_fd {
+                    match arapuca::bridge::fork_bridge(0, None, Some(dns_fd)) {
+                        Ok(_) => {
+                            audit_layer(audit_fd, "DnsCapture", true, None);
+                        }
+                        Err(e) => {
+                            audit_layer(audit_fd, "DnsCapture", false, Some(&e.to_string()));
+                            eprintln!("arapuca: dns bridge: {e}");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+            }
             Err(e) => {
                 eprintln!("arapuca: bridge: {e}");
                 std::process::exit(1);

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -182,6 +182,13 @@ fn main() {
             ..Default::default()
         };
 
+        // Bind-mount resolv.conf when DNS capture is active (before
+        // Landlock, since we need to write a temp file).
+        if std::env::var("ARAPUCA_DNS_AUDIT_FD").is_ok() {
+            let ok = arapuca::wrapper::override_resolv_conf();
+            audit_layer(audit_fd, "ResolvConfOverride", ok, None);
+        }
+
         if let Err(e) = arapuca::landlock::apply(&profile) {
             audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
             eprintln!("arapuca: landlock: {e}");

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -203,11 +203,12 @@ pub fn parse_bridge_env() -> crate::Result<Option<(u16, std::path::PathBuf)>> {
     Ok(Some((port, std::path::PathBuf::from(uds_path))))
 }
 
-/// Fork a TCP-to-UDS proxy bridge child process.
+/// Fork a bridge child process for TCP-to-UDS relay and/or DNS capture.
 ///
-/// Brings up loopback, binds a TCP listener on `127.0.0.1:port`,
-/// forks a child that relays TCP connections to the UDS at `uds_path`,
-/// and waits for child readiness. Returns the actual bound port.
+/// When `uds_path` is `Some`, binds a TCP listener on `127.0.0.1:port`
+/// and relays connections to the UDS. When `None`, runs in DNS-only
+/// mode (no TCP listener, no relay). Returns the actual bound port,
+/// or `0` in DNS-only mode.
 ///
 /// The bridge child applies its own seccomp filter and runs until
 /// killed by `PR_SET_PDEATHSIG`. It never returns.
@@ -222,7 +223,11 @@ pub fn parse_bridge_env() -> crate::Result<Option<(u16, std::path::PathBuf)>> {
 /// Returns an error if loopback cannot be brought up, the listener
 /// cannot be bound, fork fails, or the bridge child fails to signal
 /// readiness within the timeout.
-pub fn fork_bridge(port: u16, uds_path: &Path, dns_audit_fd: Option<RawFd>) -> crate::Result<u16> {
+pub fn fork_bridge(
+    port: u16,
+    uds_path: Option<&Path>,
+    dns_audit_fd: Option<RawFd>,
+) -> crate::Result<u16> {
     #[cfg(seccomp_supported)]
     {
         // SAFETY: PR_GET_SECCOMP is a simple query, no pointer args.
@@ -236,9 +241,15 @@ pub fn fork_bridge(port: u16, uds_path: &Path, dns_audit_fd: Option<RawFd>) -> c
 
     loopback_up().map_err(|e| crate::Error::Process(format!("bridge: loopback: {e}")))?;
 
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    let listener = TcpListener::bind(addr)
-        .map_err(|e| crate::Error::Process(format!("bridge: bind {addr}: {e}")))?;
+    let listener = if uds_path.is_some() {
+        let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+        Some(
+            TcpListener::bind(addr)
+                .map_err(|e| crate::Error::Process(format!("bridge: bind {addr}: {e}")))?,
+        )
+    } else {
+        None
+    };
 
     // Pre-bind DNS capture UDP socket before fork (before seccomp).
     let dns_udp = if dns_audit_fd.is_some() {
@@ -274,8 +285,6 @@ pub fn fork_bridge(port: u16, uds_path: &Path, dns_audit_fd: Option<RawFd>) -> c
         });
     }
 
-    let listener_fd = listener.as_raw_fd();
-
     if child_pid == 0 {
         // ── Bridge child ──────────────────────────────────────
         // All error exits use _exit (child can never return).
@@ -285,7 +294,10 @@ pub fn fork_bridge(port: u16, uds_path: &Path, dns_audit_fd: Option<RawFd>) -> c
 
         // Close all FDs >= 3 except those we need to keep.
         unsafe {
-            let mut keep_vec = vec![pipe_write, listener_fd];
+            let mut keep_vec = vec![pipe_write];
+            if let Some(ref l) = listener {
+                keep_vec.push(l.as_raw_fd());
+            }
             if let Some(ref udp) = dns_udp {
                 keep_vec.push(udp.as_raw_fd());
             }
@@ -342,15 +354,32 @@ pub fn fork_bridge(port: u16, uds_path: &Path, dns_audit_fd: Option<RawFd>) -> c
             std::thread::spawn(move || dns_serve(udp, audit_fd));
         }
 
-        if let Err(e) = listen_and_relay(listener, uds_path, pipe_write) {
-            child_stderr(&format!("bridge: relay: {e}\n"));
+        match (listener, uds_path) {
+            (Some(l), Some(p)) => {
+                if let Err(e) = listen_and_relay(l, p, pipe_write) {
+                    child_stderr(&format!("bridge: relay: {e}\n"));
+                }
+            }
+            _ => {
+                // DNS-only mode: signal readiness and block.
+                unsafe {
+                    libc::write(pipe_write, [1u8].as_ptr().cast(), 1);
+                    libc::close(pipe_write);
+                }
+                loop {
+                    std::thread::park();
+                }
+            }
         }
         unsafe { libc::_exit(0) };
     }
 
     // ── Parent ────────────────────────────────────────────────
 
-    let actual_port = listener.local_addr().expect("bound listener").port();
+    let actual_port = listener
+        .as_ref()
+        .map(|l| l.local_addr().expect("bound listener").port())
+        .unwrap_or(0);
     drop(listener);
 
     // SAFETY: pipe_write is a valid fd from pipe2.

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -222,7 +222,7 @@ pub fn parse_bridge_env() -> crate::Result<Option<(u16, std::path::PathBuf)>> {
 /// Returns an error if loopback cannot be brought up, the listener
 /// cannot be bound, fork fails, or the bridge child fails to signal
 /// readiness within the timeout.
-pub fn fork_bridge(port: u16, uds_path: &Path) -> crate::Result<u16> {
+pub fn fork_bridge(port: u16, uds_path: &Path, dns_audit_fd: Option<RawFd>) -> crate::Result<u16> {
     #[cfg(seccomp_supported)]
     {
         // SAFETY: PR_GET_SECCOMP is a simple query, no pointer args.
@@ -239,6 +239,16 @@ pub fn fork_bridge(port: u16, uds_path: &Path) -> crate::Result<u16> {
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(addr)
         .map_err(|e| crate::Error::Process(format!("bridge: bind {addr}: {e}")))?;
+
+    // Pre-bind DNS capture UDP socket before fork (before seccomp).
+    let dns_udp = if dns_audit_fd.is_some() {
+        let udp_addr = std::net::SocketAddr::from(([0, 0, 0, 0], 53));
+        let udp = std::net::UdpSocket::bind(udp_addr)
+            .map_err(|e| crate::Error::Process(format!("bridge: dns bind {udp_addr}: {e}")))?;
+        Some(udp)
+    } else {
+        None
+    };
 
     // Create readiness pipe.
     let mut pipe_fds = [0i32; 2];
@@ -273,12 +283,19 @@ pub fn fork_bridge(port: u16, uds_path: &Path) -> crate::Result<u16> {
         // SAFETY: pipe_read is a valid fd from pipe2.
         unsafe { libc::close(pipe_read) };
 
-        // Close all FDs >= 3 except pipe_write and listener_fd.
+        // Close all FDs >= 3 except those we need to keep.
         unsafe {
-            let mut keep = [pipe_write, listener_fd];
-            keep.sort();
+            let mut keep_vec = vec![pipe_write, listener_fd];
+            if let Some(ref udp) = dns_udp {
+                keep_vec.push(udp.as_raw_fd());
+            }
+            if let Some(fd) = dns_audit_fd {
+                keep_vec.push(fd);
+            }
+            keep_vec.sort();
+            keep_vec.dedup();
             let mut start = 3i32;
-            for &fd in &keep {
+            for &fd in &keep_vec {
                 if fd > start {
                     libc::syscall(libc::SYS_close_range, start as u32, (fd - 1) as u32, 0u32);
                 }
@@ -286,6 +303,20 @@ pub fn fork_bridge(port: u16, uds_path: &Path) -> crate::Result<u16> {
             }
             libc::syscall(libc::SYS_close_range, start as u32, u32::MAX, 0u32);
         }
+
+        // Set dns_audit_fd to non-blocking to avoid stalling on pipe full.
+        if let Some(fd) = dns_audit_fd {
+            unsafe {
+                let flags = libc::fcntl(fd, libc::F_GETFL);
+                if flags >= 0 {
+                    libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+                }
+            }
+        }
+
+        // Ignore SIGPIPE so that writing to a broken audit pipe
+        // returns EPIPE instead of killing the bridge process.
+        unsafe { libc::signal(libc::SIGPIPE, libc::SIG_IGN) };
 
         // SAFETY: prctl with PR_SET_PDEATHSIG is a simple setter.
         unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
@@ -305,6 +336,11 @@ pub fn fork_bridge(port: u16, uds_path: &Path) -> crate::Result<u16> {
         }
         #[cfg(not(seccomp_supported))]
         child_stderr("bridge: seccomp not available\n");
+
+        // Spawn DNS capture thread if enabled.
+        if let (Some(udp), Some(audit_fd)) = (dns_udp, dns_audit_fd) {
+            std::thread::spawn(move || dns_serve(udp, audit_fd));
+        }
 
         if let Err(e) = listen_and_relay(listener, uds_path, pipe_write) {
             child_stderr(&format!("bridge: relay: {e}\n"));
@@ -727,6 +763,57 @@ pub fn listen_and_relay(listener: TcpListener, uds_path: &Path, ready_fd: RawFd)
     }
 
     Ok(())
+}
+
+// ─── DNS capture ─────────────────────────────────────────────
+
+/// Serve DNS queries on a pre-bound UDP socket, logging each
+/// query domain to the audit pipe and responding with NXDOMAIN.
+///
+/// Runs in a dedicated thread inside the bridge child process.
+/// Killed by SIGKILL (pdeathsig) when the parent exits.
+fn dns_serve(udp: std::net::UdpSocket, audit_fd: RawFd) {
+    let mut buf = [0u8; 4096];
+    let mut dropped: u64 = 0;
+    loop {
+        let (n, src) = match udp.recv_from(&mut buf) {
+            Ok(r) => r,
+            Err(e) => {
+                if e.kind() != io::ErrorKind::Interrupted && e.kind() != io::ErrorKind::WouldBlock {
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                continue;
+            }
+        };
+
+        if n < 12 || buf[2] & 0x80 != 0 {
+            continue;
+        }
+
+        let id = u16::from_be_bytes([buf[0], buf[1]]);
+
+        let line: Vec<u8> = if let Some(query) = crate::dns::parse_query(&buf[..n]) {
+            let escaped = crate::wrapper::json_escape(&query.domain);
+            let qtype = crate::dns::qtype_name(query.qtype);
+            format!("{{\"domain\":\"{escaped}\",\"qtype\":\"{qtype}\"}}\n").into_bytes()
+        } else {
+            b"{\"domain\":\"<unparseable>\",\"qtype\":\"UNKNOWN\"}\n".to_vec()
+        };
+
+        let ret = unsafe { libc::write(audit_fd, line.as_ptr().cast(), line.len()) };
+        if ret < 0 && io::Error::last_os_error().kind() == io::ErrorKind::WouldBlock {
+            dropped += 1;
+        } else if dropped > 0 {
+            let summary = format!("{{\"dropped\":{dropped}}}\n");
+            let _ = unsafe { libc::write(audit_fd, summary.as_ptr().cast(), summary.len()) };
+            dropped = 0;
+        }
+
+        let resp = crate::dns::build_nxdomain(&buf[..n], id);
+        if !resp.is_empty() {
+            let _ = udp.send_to(&resp, src);
+        }
+    }
 }
 
 // ─── CONNECT proxy ───────────────────────────────────────────

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,0 +1,406 @@
+//! Minimal DNS wire format parser for query capture.
+//!
+//! Parses standard DNS query packets (RFC 1035) to extract the
+//! queried domain name and type, and constructs NXDOMAIN responses.
+//! Only handles the question section — no compression pointers,
+//! answer/authority/additional parsing.
+
+/// A parsed DNS query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsQuery {
+    pub id: u16,
+    pub domain: String,
+    pub qtype: u16,
+    pub qclass: u16,
+}
+
+const HEADER_LEN: usize = 12;
+const MAX_NAME_LEN: usize = 253;
+const MAX_LABEL_LEN: usize = 63;
+
+/// Parse a DNS query from a UDP payload.
+///
+/// Returns `None` on malformed input, responses (QR=1), or labels
+/// containing characters outside `[a-zA-Z0-9-_]`.
+pub fn parse_query(buf: &[u8]) -> Option<DnsQuery> {
+    if buf.len() < HEADER_LEN {
+        return None;
+    }
+
+    let id = u16::from_be_bytes([buf[0], buf[1]]);
+    let flags = u16::from_be_bytes([buf[2], buf[3]]);
+
+    // QR bit must be 0 (query).
+    if flags & 0x8000 != 0 {
+        return None;
+    }
+
+    let qdcount = u16::from_be_bytes([buf[4], buf[5]]);
+    if qdcount == 0 {
+        return None;
+    }
+
+    // Parse the first question's QNAME.
+    let mut pos = HEADER_LEN;
+    let mut labels: Vec<&str> = Vec::new();
+    let mut name_len: usize = 0;
+
+    loop {
+        if pos >= buf.len() {
+            return None;
+        }
+
+        let label_len = buf[pos] as usize;
+        pos += 1;
+
+        if label_len == 0 {
+            break;
+        }
+
+        // Reject compression pointers (top 2 bits set).
+        if label_len > MAX_LABEL_LEN {
+            return None;
+        }
+
+        if pos + label_len > buf.len() {
+            return None;
+        }
+
+        let label_bytes = &buf[pos..pos + label_len];
+
+        // Validate label characters: only [a-zA-Z0-9-].
+        // The dot separator is implicit (between labels), not in labels.
+        for &b in label_bytes {
+            if !b.is_ascii_alphanumeric() && b != b'-' && b != b'_' {
+                return None;
+            }
+        }
+
+        let label = std::str::from_utf8(label_bytes).ok()?;
+
+        // Track total name length (labels + dots).
+        if !labels.is_empty() {
+            name_len += 1; // dot separator
+        }
+        name_len += label_len;
+        if name_len > MAX_NAME_LEN {
+            return None;
+        }
+
+        labels.push(label);
+        pos += label_len;
+    }
+
+    // Need at least QTYPE (2) + QCLASS (2) after QNAME.
+    if pos + 4 > buf.len() {
+        return None;
+    }
+
+    let qtype = u16::from_be_bytes([buf[pos], buf[pos + 1]]);
+    let qclass = u16::from_be_bytes([buf[pos + 2], buf[pos + 3]]);
+
+    let domain = if labels.is_empty() {
+        ".".to_string() // root domain
+    } else {
+        labels.join(".")
+    };
+
+    Some(DnsQuery {
+        id,
+        domain,
+        qtype,
+        qclass,
+    })
+}
+
+/// Build a minimal NXDOMAIN response for a DNS query.
+///
+/// Copies the header and question section from the original query,
+/// setting QR=1 (response), AA=1 (authoritative), and RCODE=3
+/// (NXDOMAIN). Answer/authority/additional counts are zeroed.
+pub fn build_nxdomain(query_buf: &[u8], id: u16) -> Vec<u8> {
+    if query_buf.len() < HEADER_LEN {
+        return Vec::new();
+    }
+
+    // Walk past the question section to find its end.
+    let mut pos = HEADER_LEN;
+    loop {
+        if pos >= query_buf.len() {
+            return Vec::new();
+        }
+        let label_len = query_buf[pos] as usize;
+        pos += 1;
+        if label_len == 0 {
+            break;
+        }
+        if label_len > MAX_LABEL_LEN || pos + label_len > query_buf.len() {
+            return Vec::new();
+        }
+        pos += label_len;
+    }
+    // Skip QTYPE + QCLASS.
+    if pos + 4 > query_buf.len() {
+        return Vec::new();
+    }
+    pos += 4;
+
+    let mut resp = Vec::with_capacity(pos);
+
+    // Copy header, then patch it.
+    resp.extend_from_slice(&query_buf[..HEADER_LEN]);
+    // ID
+    resp[0] = (id >> 8) as u8;
+    resp[1] = id as u8;
+    // Flags: QR=1, AA=1, RCODE=3 (NXDOMAIN).
+    // Preserve the original opcode (bits 11-14) and RD (bit 8).
+    let orig_flags = u16::from_be_bytes([query_buf[2], query_buf[3]]);
+    let opcode = orig_flags & 0x7800; // bits 11-14
+    let rd = orig_flags & 0x0100; // bit 8
+    let new_flags: u16 = 0x8000 | opcode | 0x0400 | rd | 0x0003;
+    resp[2] = (new_flags >> 8) as u8;
+    resp[3] = new_flags as u8;
+    // Force QDCOUNT=1 (we only include one question section).
+    resp[4] = 0;
+    resp[5] = 1;
+    // Zero out ANCOUNT, NSCOUNT, ARCOUNT.
+    resp[6] = 0;
+    resp[7] = 0;
+    resp[8] = 0;
+    resp[9] = 0;
+    resp[10] = 0;
+    resp[11] = 0;
+
+    // Copy question section.
+    resp.extend_from_slice(&query_buf[HEADER_LEN..pos]);
+
+    resp
+}
+
+/// Map a DNS query type number to a human-readable name.
+pub fn qtype_name(qtype: u16) -> &'static str {
+    match qtype {
+        1 => "A",
+        2 => "NS",
+        5 => "CNAME",
+        6 => "SOA",
+        12 => "PTR",
+        15 => "MX",
+        16 => "TXT",
+        28 => "AAAA",
+        33 => "SRV",
+        35 => "NAPTR",
+        43 => "DS",
+        46 => "RRSIG",
+        48 => "DNSKEY",
+        52 => "TLSA",
+        65 => "HTTPS",
+        255 => "ANY",
+        _ => "OTHER",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_query(domain: &str, qtype: u16) -> Vec<u8> {
+        let mut buf = Vec::new();
+        // Header: ID=0x1234, flags=0x0100 (RD=1), QDCOUNT=1
+        buf.extend_from_slice(&[0x12, 0x34, 0x01, 0x00, 0x00, 0x01]);
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        // QNAME
+        if domain == "." {
+            buf.push(0);
+        } else {
+            for label in domain.split('.') {
+                buf.push(label.len() as u8);
+                buf.extend_from_slice(label.as_bytes());
+            }
+            buf.push(0);
+        }
+
+        // QTYPE + QCLASS (IN=1)
+        buf.push((qtype >> 8) as u8);
+        buf.push(qtype as u8);
+        buf.push(0x00);
+        buf.push(0x01);
+
+        buf
+    }
+
+    #[test]
+    fn parse_a_query() {
+        let buf = build_query("example.com", 1);
+        let q = parse_query(&buf).unwrap();
+        assert_eq!(q.id, 0x1234);
+        assert_eq!(q.domain, "example.com");
+        assert_eq!(q.qtype, 1);
+        assert_eq!(q.qclass, 1);
+    }
+
+    #[test]
+    fn parse_aaaa_query() {
+        let buf = build_query("ipv6.example.org", 28);
+        let q = parse_query(&buf).unwrap();
+        assert_eq!(q.domain, "ipv6.example.org");
+        assert_eq!(q.qtype, 28);
+    }
+
+    #[test]
+    fn parse_mx_query() {
+        let buf = build_query("mail.example.com", 15);
+        let q = parse_query(&buf).unwrap();
+        assert_eq!(q.domain, "mail.example.com");
+        assert_eq!(q.qtype, 15);
+    }
+
+    #[test]
+    fn parse_root_domain() {
+        let buf = build_query(".", 2);
+        let q = parse_query(&buf).unwrap();
+        assert_eq!(q.domain, ".");
+        assert_eq!(q.qtype, 2);
+    }
+
+    #[test]
+    fn reject_truncated_header() {
+        assert!(parse_query(&[0; 11]).is_none());
+    }
+
+    #[test]
+    fn reject_truncated_name() {
+        let mut buf = build_query("example.com", 1);
+        buf.truncate(18); // cut in the middle of the name
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_truncated_qtype() {
+        let mut buf = build_query("example.com", 1);
+        buf.truncate(buf.len() - 2); // remove QCLASS
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_response_packet() {
+        let mut buf = build_query("example.com", 1);
+        buf[2] |= 0x80; // set QR=1 (response)
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_zero_qdcount() {
+        let mut buf = build_query("example.com", 1);
+        buf[4] = 0;
+        buf[5] = 0;
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_oversized_label() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&[0x00, 0x01, 0x01, 0x00, 0x00, 0x01]);
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        buf.push(64); // label length 64 > MAX_LABEL_LEN (63)
+        buf.extend_from_slice(&[b'a'; 64]);
+        buf.push(0);
+        buf.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]);
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_injection_characters() {
+        // Domain with quotes — would break NDJSON if not rejected.
+        let mut buf = build_query("dummy", 1);
+        // Overwrite the label with bytes containing a quote.
+        let label_start = HEADER_LEN + 1; // after length byte
+        buf[label_start] = b'"';
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_newline_in_label() {
+        let mut buf = build_query("dummy", 1);
+        let label_start = HEADER_LEN + 1;
+        buf[label_start] = b'\n';
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn reject_brace_in_label() {
+        let mut buf = build_query("dummy", 1);
+        let label_start = HEADER_LEN + 1;
+        buf[label_start] = b'{';
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn accept_hyphen_and_underscore() {
+        let buf = build_query("my-host_name.example.com", 1);
+        let q = parse_query(&buf).unwrap();
+        assert_eq!(q.domain, "my-host_name.example.com");
+    }
+
+    #[test]
+    fn max_length_name() {
+        // 253 chars: 63.63.63.63 (63*4 + 3 dots = 255 > 253, so use shorter)
+        // Use 4 labels of 62 chars + dots = 62*4 + 3 = 251
+        let label = "a".repeat(62);
+        let domain = format!("{label}.{label}.{label}.{label}");
+        assert_eq!(domain.len(), 251);
+        let buf = build_query(&domain, 1);
+        let q = parse_query(&buf).unwrap();
+        assert_eq!(q.domain, domain);
+    }
+
+    #[test]
+    fn over_max_length_name() {
+        let label = "a".repeat(63);
+        let domain = format!("{label}.{label}.{label}.{label}");
+        assert!(domain.len() > MAX_NAME_LEN);
+        let buf = build_query(&domain, 1);
+        assert!(parse_query(&buf).is_none());
+    }
+
+    #[test]
+    fn nxdomain_response_structure() {
+        let query = build_query("evil.com", 1);
+        let resp = build_nxdomain(&query, 0x1234);
+
+        assert!(resp.len() >= HEADER_LEN);
+        // ID
+        assert_eq!(resp[0], 0x12);
+        assert_eq!(resp[1], 0x34);
+        // QR=1
+        assert_ne!(resp[2] & 0x80, 0);
+        // AA=1
+        assert_ne!(resp[2] & 0x04, 0);
+        // RCODE=3 (NXDOMAIN)
+        assert_eq!(resp[3] & 0x0F, 3);
+        // RD preserved from query
+        assert_ne!(resp[2] & 0x01, 0);
+        // QDCOUNT=1
+        assert_eq!(u16::from_be_bytes([resp[4], resp[5]]), 1);
+        // ANCOUNT=0
+        assert_eq!(u16::from_be_bytes([resp[6], resp[7]]), 0);
+    }
+
+    #[test]
+    fn nxdomain_rejects_short_input() {
+        assert!(build_nxdomain(&[0; 5], 0).is_empty());
+    }
+
+    #[test]
+    fn qtype_names() {
+        assert_eq!(qtype_name(1), "A");
+        assert_eq!(qtype_name(28), "AAAA");
+        assert_eq!(qtype_name(5), "CNAME");
+        assert_eq!(qtype_name(15), "MX");
+        assert_eq!(qtype_name(16), "TXT");
+        assert_eq!(qtype_name(33), "SRV");
+        assert_eq!(qtype_name(255), "ANY");
+        assert_eq!(qtype_name(9999), "OTHER");
+    }
+}

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -68,7 +68,7 @@ pub fn parse_query(buf: &[u8]) -> Option<DnsQuery> {
 
         let label_bytes = &buf[pos..pos + label_len];
 
-        // Validate label characters: only [a-zA-Z0-9-].
+        // Validate label characters: only [a-zA-Z0-9-_].
         // The dot separator is implicit (between labels), not in labels.
         for &b in label_bytes {
             if !b.is_ascii_alphanumeric() && b != b'-' && b != b'_' {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -234,6 +234,26 @@ pub unsafe extern "C" fn arapuca_profile_set_netns(profile: *mut ArapucaProfile,
     }
 }
 
+/// Enable DNS query capture inside the network namespace.
+///
+/// When enabled alongside netns, the bridge child intercepts DNS
+/// queries and emits `NetworkBlocked` audit events. Requires the
+/// `serde` feature and the wrapper binary with filesystem paths.
+///
+/// # Safety
+/// `profile` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_dns_capture(
+    profile: *mut ArapucaProfile,
+    enabled: bool,
+) {
+    if let Some(profile) = unsafe { profile.as_mut() } {
+        if let Some(inner) = profile.inner.as_mut() {
+            inner.dns_capture = enabled;
+        }
+    }
+}
+
 /// Set micro-VM isolation on a profile with a distro image source.
 ///
 /// After this call, launching with this profile creates a VM instead

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod bridge;
 #[cfg(target_os = "linux")]
 pub mod cgroup;
 pub mod diskquota;
+pub mod dns;
 pub mod env;
 mod error;
 pub mod ffi;

--- a/src/netns.rs
+++ b/src/netns.rs
@@ -28,6 +28,31 @@ pub fn available() -> bool {
     }
 }
 
+/// Probe whether mount namespace isolation works alongside netns.
+///
+/// Tests `unshare --user --net --mount --map-current-user -- /bin/true`.
+/// Required for DNS capture (bind-mounting resolv.conf). Falls back
+/// gracefully to netns-only if mount ns is unavailable.
+pub fn mount_ns_available() -> bool {
+    let result = Command::new("unshare")
+        .args([
+            "--user",
+            "--net",
+            "--mount",
+            "--map-current-user",
+            "--",
+            "/bin/true",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    match result {
+        Ok(status) => status.success(),
+        Err(_) => false,
+    }
+}
+
 /// Timeout for the netns probe.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -584,6 +584,8 @@ impl Sandbox for Darwin {
             });
         }
 
+        let pre_spawn_time = std::time::SystemTime::now();
+
         let child = command.spawn().map_err(|e| {
             if let Some(m) = pty_master_fd {
                 // SAFETY: valid FD from openpty, cleanup on spawn failure.
@@ -635,11 +637,17 @@ impl Sandbox for Darwin {
             });
         }
 
+        let capture_denials = !allow_network && audit_ctx.is_some();
+
         Ok(Process {
             child: crate::process::ChildHandle::Managed(child),
             tmp_dir: tmp_guard.defuse(),
-            // SAFETY: fd is a valid master FD from openpty with CLOEXEC set.
             pty_master: pty_master_fd.map(|fd| unsafe { OwnedFd::from_raw_fd(fd) }),
+            launch_timestamp: if capture_denials {
+                Some(pre_spawn_time)
+            } else {
+                None
+            },
             audit_ctx,
             final_stats: None,
         })

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -212,10 +212,38 @@ impl Sandbox for Linux {
             }
         }
 
+        // ── DNS capture eligibility ────────────────────────────────
+        #[cfg(feature = "serde")]
+        let dns_capture_active = cfg.profile.dns_capture
+            && cfg.profile.use_netns
+            && cfg.network_proxy_socket.is_some()
+            && crate::netns::mount_ns_available();
+        #[cfg(not(feature = "serde"))]
+        let dns_capture_active = false;
+
+        if cfg.profile.dns_capture && !dns_capture_active {
+            if !cfg!(feature = "serde") {
+                log::warn!("DNS capture requires the 'serde' feature");
+            } else if cfg.network_proxy_socket.is_none() {
+                log::warn!(
+                    "DNS capture requires a network proxy socket (bridge provides DNS server)"
+                );
+            } else if !crate::netns::mount_ns_available() {
+                log::warn!(
+                    "DNS capture requires mount namespace support (unshare --mount); \
+                     falling back to netns-only"
+                );
+            }
+        }
+
         // ── Network namespace ──────────────────────────────────────
         let mut command = if cfg.profile.use_netns {
             let mut c = Command::new("unshare");
-            c.args(["--user", "--net", "--map-current-user", "--"]);
+            if dns_capture_active && use_landlock {
+                c.args(["--user", "--net", "--mount", "--map-current-user", "--"]);
+            } else {
+                c.args(["--user", "--net", "--map-current-user", "--"]);
+            }
             c.arg(&actual_cmd);
             c.args(&actual_args);
             if let Some(ref ctx) = audit_ctx {
@@ -399,6 +427,28 @@ impl Sandbox for Linux {
         // a pipe so the wrapper can report which layers it actually
         // applied. The write end is passed as an extra FD; the parent
         // reads from the read end after spawn.
+        //
+        // Pipe FDs are tracked in pipe_guard so early returns (? on
+        // emit calls between pipe creation and spawn) close them
+        // automatically via Drop. Defused after spawn succeeds.
+        struct PipeGuard(Vec<RawFd>);
+        impl PipeGuard {
+            fn push(&mut self, fd: RawFd) {
+                self.0.push(fd);
+            }
+            fn defuse(mut self) {
+                self.0.clear();
+            }
+        }
+        impl Drop for PipeGuard {
+            fn drop(&mut self) {
+                for &fd in &self.0 {
+                    unsafe { libc::close(fd) };
+                }
+            }
+        }
+        let mut pipe_guard = PipeGuard(Vec::new());
+
         let audit_pipe = if audit_ctx.is_some() && use_landlock {
             let mut fds = [0i32; 2];
             // SAFETY: fds is a valid 2-element array. O_CLOEXEC prevents
@@ -410,6 +460,8 @@ impl Sandbox for Linux {
                 // the lowest unused FDs, so the write-end cannot collide
                 // with any already-open user FD in fds_to_inherit.
                 fds_to_inherit.push(fds[1]);
+                pipe_guard.push(fds[0]);
+                pipe_guard.push(fds[1]);
                 Some((fds[0], fds[1], target_fd))
             } else {
                 log::warn!("audit pipe creation failed, continuing without");
@@ -422,6 +474,59 @@ impl Sandbox for Linux {
         // Add ARAPUCA_AUDIT_FD to wrapper env so it knows which FD to write to.
         if let Some((_, _, target_fd)) = audit_pipe {
             command.env("ARAPUCA_AUDIT_FD", target_fd.to_string());
+        }
+
+        // ── DNS audit pipe ────────────────────────────────────────
+        // When DNS capture is enabled, create a pipe for the bridge's
+        // DNS server to write NDJSON audit lines. The parent reads
+        // these after the process exits and emits NetworkBlocked events.
+        let dns_audit_pipe = if dns_capture_active && use_landlock {
+            let mut fds = [0i32; 2];
+            let ret = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+            if ret == 0 {
+                let target_fd = 3 + fds_to_inherit.len() as i32;
+                fds_to_inherit.push(fds[1]);
+                command.env("ARAPUCA_DNS_AUDIT_FD", target_fd.to_string());
+                pipe_guard.push(fds[0]);
+                pipe_guard.push(fds[1]);
+                Some((fds[0], fds[1]))
+            } else {
+                log::warn!("DNS audit pipe creation failed, continuing without");
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(ref ctx) = audit_ctx {
+            if dns_audit_pipe.is_some() {
+                ctx.emit(AuditEvent::LayerApplied {
+                    timestamp: ctx.timestamp(),
+                    layer: SandboxLayer::DnsCapture,
+                    detail: Some(LayerDetail::DnsCapture { port: 53 }),
+                })?;
+                applied_layers.push(SandboxLayer::DnsCapture);
+            } else {
+                let reason = if !cfg.profile.dns_capture {
+                    SkipReason::NotConfigured
+                } else if !cfg!(feature = "serde") {
+                    SkipReason::ComponentMissing(
+                        "serde feature required for DNS audit parsing".into(),
+                    )
+                } else if !use_landlock {
+                    SkipReason::ComponentMissing(
+                        "wrapper binary with filesystem paths required".into(),
+                    )
+                } else {
+                    SkipReason::PartialFailure("mount namespace unavailable".into())
+                };
+                ctx.emit(AuditEvent::LayerSkipped {
+                    timestamp: ctx.timestamp(),
+                    layer: SandboxLayer::DnsCapture,
+                    reason,
+                })?;
+                skipped_layers.push(SandboxLayer::DnsCapture);
+            }
         }
 
         // ── Emit pre_exec layer events from parent ─────────────────
@@ -661,6 +766,11 @@ impl Sandbox for Linux {
         }
 
         // ── Spawn ──────────────────────────────────────────────────
+        // Defuse the pipe guard — from here on, pipes are closed
+        // explicitly (error handler on spawn failure, or post-spawn
+        // cleanup on success).
+        pipe_guard.defuse();
+
         let child = command.spawn().map_err(|e| {
             if let Some(ref ctx) = audit_ctx {
                 let _ = ctx.emit(AuditEvent::LayerFailed {
@@ -670,7 +780,12 @@ impl Sandbox for Linux {
                 });
             }
             if let Some((read_fd, write_fd, _)) = audit_pipe {
-                // SAFETY: valid FDs from pipe().
+                unsafe {
+                    libc::close(read_fd);
+                    libc::close(write_fd);
+                }
+            }
+            if let Some((read_fd, write_fd)) = dns_audit_pipe {
                 unsafe {
                     libc::close(read_fd);
                     libc::close(write_fd);
@@ -713,6 +828,15 @@ impl Sandbox for Linux {
             unsafe { libc::close(read_fd) };
         }
 
+        // Close DNS audit pipe write end in parent. The read end is
+        // kept open — Process::wait() reads it after the child exits.
+        let dns_audit_read_fd = if let Some((read_fd, write_fd)) = dns_audit_pipe {
+            unsafe { libc::close(write_fd) };
+            Some(read_fd)
+        } else {
+            None
+        };
+
         // ── Emit ProcessStarted ────────────────────────────────────
         if let Some(ref ctx) = audit_ctx {
             ctx.emit(AuditEvent::ProcessStarted {
@@ -746,6 +870,7 @@ impl Sandbox for Linux {
             tmp_dir: tmp_guard.defuse(),
             cgroup_path,
             cgroup_mgr: self.cgroup_mgr.clone(),
+            dns_audit_pipe: dns_audit_read_fd,
             #[cfg(feature = "microvm")]
             passt: None,
             pty_master: pty_master_fd.map(|fd| {

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -213,22 +213,14 @@ impl Sandbox for Linux {
         }
 
         // ── DNS capture eligibility ────────────────────────────────
-        #[cfg(feature = "serde")]
-        let dns_capture_active = cfg.profile.dns_capture
-            && cfg.profile.use_netns
-            && cfg.network_proxy_socket.is_some()
-            && crate::netns::mount_ns_available();
-        #[cfg(not(feature = "serde"))]
-        let dns_capture_active = false;
+        let mount_ns_ok =
+            cfg.profile.dns_capture && cfg.profile.use_netns && crate::netns::mount_ns_available();
+        let dns_capture_active = mount_ns_ok;
 
         if cfg.profile.dns_capture && !dns_capture_active {
-            if !cfg!(feature = "serde") {
-                log::warn!("DNS capture requires the 'serde' feature");
-            } else if cfg.network_proxy_socket.is_none() {
-                log::warn!(
-                    "DNS capture requires a network proxy socket (bridge provides DNS server)"
-                );
-            } else if !crate::netns::mount_ns_available() {
+            if !cfg.profile.use_netns {
+                log::warn!("DNS capture requires use_netns");
+            } else if !mount_ns_ok {
                 log::warn!(
                     "DNS capture requires mount namespace support (unshare --mount); \
                      falling back to netns-only"

--- a/src/platform/microvm.rs
+++ b/src/platform/microvm.rs
@@ -444,6 +444,8 @@ fn launch_vm(
         cgroup_path: None,
         #[cfg(target_os = "linux")]
         cgroup_mgr: None,
+        #[cfg(target_os = "linux")]
+        dns_audit_pipe: None,
         passt: None,
         pty_master: None,
         audit_ctx,

--- a/src/process.rs
+++ b/src/process.rs
@@ -37,6 +37,9 @@ pub struct Process {
     /// Cgroup path (None if no cgroup). Linux only.
     #[cfg(target_os = "linux")]
     pub(crate) cgroup_path: Option<PathBuf>,
+    /// DNS audit pipe read end. Read in wait() after child exits.
+    #[cfg(target_os = "linux")]
+    pub(crate) dns_audit_pipe: Option<std::os::unix::io::RawFd>,
     /// Reference to the cgroup manager for stats/cleanup. Linux only.
     #[cfg(target_os = "linux")]
     pub(crate) cgroup_mgr: Option<std::sync::Arc<crate::cgroup::CgroupManager>>,
@@ -124,6 +127,11 @@ impl Process {
                 std::process::ExitStatus::from_raw(wstatus)
             }
         };
+
+        // Read DNS audit pipe before emitting ProcessExited, so
+        // NetworkBlocked events appear in the event stream before
+        // the exit event.
+        self.read_dns_audit_pipe(pid);
 
         // Capture stats while cgroup still exists (before cleanup
         // destroys it). Eliminates the TOCTOU gap.
@@ -213,6 +221,120 @@ impl Process {
 
         Ok(status)
     }
+
+    /// Read DNS audit events from the bridge child's pipe and emit
+    /// `NetworkBlocked` events via the audit context.
+    #[cfg(target_os = "linux")]
+    #[cfg_attr(not(feature = "serde"), allow(unused_variables))]
+    fn read_dns_audit_pipe(&mut self, pid: u32) {
+        let fd = match self.dns_audit_pipe.take() {
+            Some(fd) => fd,
+            None => return,
+        };
+
+        // Poll with a 1-second timeout — the bridge should be dead
+        // (pdeathsig) by now, but SIGKILL delivery is asynchronous.
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let poll_ret = loop {
+            let ret = unsafe { libc::poll(&mut pfd, 1, 1000) };
+            if ret >= 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+                break ret;
+            }
+        };
+        if poll_ret == 0 {
+            log::warn!("DNS audit pipe: timeout waiting for EOF (bridge may still be alive)");
+            unsafe { libc::close(fd) };
+            return;
+        }
+
+        // Read all available data. Set O_NONBLOCK so we never block
+        // waiting for the bridge child to die (SIGKILL is asynchronous).
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFL);
+            if flags >= 0 {
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+        let mut data = Vec::new();
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+            if n < 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
+                if err.raw_os_error() == Some(libc::EAGAIN) {
+                    let mut pfd = libc::pollfd {
+                        fd,
+                        events: libc::POLLIN,
+                        revents: 0,
+                    };
+                    let ret = unsafe { libc::poll(&mut pfd, 1, 1000) };
+                    if ret <= 0 {
+                        break;
+                    }
+                    continue;
+                }
+                break;
+            }
+            if n == 0 {
+                break;
+            }
+            data.extend_from_slice(&buf[..n as usize]);
+        }
+        unsafe { libc::close(fd) };
+
+        #[cfg(not(feature = "serde"))]
+        if !data.is_empty() {
+            log::warn!(
+                "DNS audit: {} bytes discarded (compile with 'serde' feature to emit events)",
+                data.len()
+            );
+        }
+
+        #[cfg(feature = "serde")]
+        if !data.is_empty() {
+            let ctx = match self.audit_ctx {
+                Some(ref ctx) => ctx,
+                None => return,
+            };
+            let text = String::from_utf8_lossy(&data);
+            for line in text.lines() {
+                if line.is_empty() {
+                    continue;
+                }
+                #[derive(serde::Deserialize)]
+                struct DnsAuditLine {
+                    domain: String,
+                    qtype: String,
+                }
+                match serde_json::from_str::<DnsAuditLine>(line) {
+                    Ok(entry) => {
+                        if let Err(e) = ctx.emit(AuditEvent::NetworkBlocked {
+                            timestamp: ctx.timestamp(),
+                            pid,
+                            destination: entry.domain,
+                            protocol: "dns".into(),
+                            detail: Some(entry.qtype),
+                        }) {
+                            log::error!("audit emit failed: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        log::debug!("DNS audit: skipping malformed line: {e}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn read_dns_audit_pipe(&mut self, _pid: u32) {}
 
     /// Read resource usage from the agent's cgroup.
     ///
@@ -324,6 +446,11 @@ impl Drop for Process {
         }
 
         #[cfg(target_os = "linux")]
+        if let Some(fd) = self.dns_audit_pipe.take() {
+            unsafe { libc::close(fd) };
+        }
+
+        #[cfg(target_os = "linux")]
         if let (Some(mgr), Some(path)) = (&self.cgroup_mgr, &self.cgroup_path) {
             let _ = mgr.destroy(path);
         }
@@ -364,6 +491,8 @@ mod tests {
                 cgroup_path: None,
                 #[cfg(target_os = "linux")]
                 cgroup_mgr: None,
+                #[cfg(target_os = "linux")]
+                dns_audit_pipe: None,
                 #[cfg(all(target_os = "linux", feature = "microvm"))]
                 passt: None,
                 pty_master: None,
@@ -372,5 +501,91 @@ mod tests {
             };
         }
         assert!(!dir.exists(), "Drop should have removed the tmpdir");
+    }
+
+    #[cfg(all(target_os = "linux", feature = "serde"))]
+    #[test]
+    fn dns_audit_pipe_emits_network_blocked() {
+        use std::sync::{Arc, Mutex};
+
+        struct VecSink(Mutex<Vec<crate::audit::AuditEvent>>);
+        impl crate::audit::AuditSink for VecSink {
+            fn emit(&self, event: crate::audit::AuditEvent) {
+                self.0.lock().unwrap().push(event);
+            }
+        }
+
+        let mut pipe_fds = [0i32; 2];
+        assert_eq!(
+            unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC) },
+            0
+        );
+        let pipe_read = pipe_fds[0];
+        let pipe_write = pipe_fds[1];
+
+        let ndjson = b"{\"domain\":\"evil.example.com\",\"qtype\":\"A\"}\n\
+                       {\"domain\":\"bad.test\",\"qtype\":\"AAAA\"}\n";
+        unsafe {
+            libc::write(pipe_write, ndjson.as_ptr().cast(), ndjson.len());
+            libc::close(pipe_write);
+        }
+
+        let vec_sink = Arc::new(VecSink(Mutex::new(Vec::new())));
+        let sink: Arc<dyn crate::audit::AuditSink> = Arc::clone(&vec_sink) as _;
+        let ctx = crate::audit::AuditContext::new(sink, crate::audit::AuditVerbosity::Standard);
+
+        let dir = crate::env::make_tmp_dir("dns-audit-test").unwrap();
+        let child = std::process::Command::new("true")
+            .spawn()
+            .expect("failed to spawn true");
+        let mut process = Process {
+            child: ChildHandle::Managed(child),
+            tmp_dir: dir,
+            cgroup_path: None,
+            cgroup_mgr: None,
+            dns_audit_pipe: Some(pipe_read),
+            #[cfg(target_os = "macos")]
+            launch_timestamp: None,
+            #[cfg(all(target_os = "linux", feature = "microvm"))]
+            passt: None,
+            pty_master: None,
+            audit_ctx: Some(ctx),
+            final_stats: None,
+        };
+
+        process.read_dns_audit_pipe(42);
+
+        let captured = vec_sink.0.lock().unwrap();
+        let blocked: Vec<_> = captured
+            .iter()
+            .filter(|e| matches!(e, crate::audit::AuditEvent::NetworkBlocked { .. }))
+            .collect();
+        assert_eq!(blocked.len(), 2, "should emit 2 NetworkBlocked events");
+
+        if let crate::audit::AuditEvent::NetworkBlocked {
+            destination,
+            protocol,
+            detail,
+            ..
+        } = &blocked[0]
+        {
+            assert_eq!(destination, "evil.example.com");
+            assert_eq!(protocol, "dns");
+            assert_eq!(detail.as_deref(), Some("A"));
+        } else {
+            panic!("expected NetworkBlocked");
+        }
+
+        if let crate::audit::AuditEvent::NetworkBlocked {
+            destination,
+            detail,
+            ..
+        } = &blocked[1]
+        {
+            assert_eq!(destination, "bad.test");
+            assert_eq!(detail.as_deref(), Some("AAAA"));
+        } else {
+            panic!("expected NetworkBlocked");
+        }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -40,6 +40,9 @@ pub struct Process {
     /// DNS audit pipe read end. Read in wait() after child exits.
     #[cfg(target_os = "linux")]
     pub(crate) dns_audit_pipe: Option<std::os::unix::io::RawFd>,
+    /// Launch timestamp for macOS Seatbelt denial log querying.
+    #[cfg(target_os = "macos")]
+    pub(crate) launch_timestamp: Option<std::time::SystemTime>,
     /// Reference to the cgroup manager for stats/cleanup. Linux only.
     #[cfg(target_os = "linux")]
     pub(crate) cgroup_mgr: Option<std::sync::Arc<crate::cgroup::CgroupManager>>,
@@ -128,10 +131,11 @@ impl Process {
             }
         };
 
-        // Read DNS audit pipe before emitting ProcessExited, so
-        // NetworkBlocked events appear in the event stream before
+        // Read blocked-network audit data before emitting
+        // ProcessExited, so NetworkBlocked events appear before
         // the exit event.
         self.read_dns_audit_pipe(pid);
+        self.read_seatbelt_denials(pid);
 
         // Capture stats while cgroup still exists (before cleanup
         // destroys it). Eliminates the TOCTOU gap.
@@ -334,7 +338,129 @@ impl Process {
     }
 
     #[cfg(not(target_os = "linux"))]
+    #[cfg_attr(windows, allow(dead_code))]
     fn read_dns_audit_pipe(&mut self, _pid: u32) {}
+
+    #[cfg(target_os = "macos")]
+    fn read_seatbelt_denials(&mut self, pid: u32) {
+        let launch_time = match self.launch_timestamp.take() {
+            Some(t) => t,
+            None => return,
+        };
+        let ctx = match self.audit_ctx {
+            Some(ref ctx) => ctx,
+            None => return,
+        };
+
+        let fmt = |t: std::time::SystemTime| -> String {
+            let d = t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+            let secs = d.as_secs();
+            let mut tm = std::mem::MaybeUninit::<libc::tm>::uninit();
+            let ts = secs as libc::time_t;
+            unsafe { libc::localtime_r(&ts, tm.as_mut_ptr()) };
+            let tm = unsafe { tm.assume_init() };
+            format!(
+                "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+                tm.tm_year + 1900,
+                tm.tm_mon + 1,
+                tm.tm_mday,
+                tm.tm_hour,
+                tm.tm_min,
+                tm.tm_sec,
+            )
+        };
+
+        let start = fmt(launch_time);
+        let end = fmt(std::time::SystemTime::now());
+        let predicate = "subsystem == \"com.apple.sandbox\" \
+             AND category == \"violation\" \
+             AND eventMessage CONTAINS \"network\"";
+
+        let mut child = match std::process::Command::new("log")
+            .args([
+                "show",
+                "--start",
+                &start,
+                "--end",
+                &end,
+                "--style",
+                "ndjson",
+                "--predicate",
+                predicate,
+            ])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("failed to spawn 'log show': {e}");
+                return;
+            }
+        };
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let output = loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break child.stdout.take(),
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        log::warn!("'log show' timed out (10s)");
+                        break None;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                Err(e) => {
+                    log::warn!("'log show' wait failed: {e}");
+                    break None;
+                }
+            }
+        };
+
+        if let Some(stdout) = output {
+            let reader = std::io::BufReader::new(stdout);
+            use std::io::BufRead;
+            for line in reader.lines() {
+                let line = match line {
+                    Ok(l) => l,
+                    Err(_) => continue,
+                };
+                if line.is_empty() {
+                    continue;
+                }
+                let pid_field = format!("\"processID\":{pid},");
+                let pid_field_end = format!("\"processID\":{pid}}}");
+                let pgid_field = format!("\"processGroupID\":{pid},");
+                let pgid_field_end = format!("\"processGroupID\":{pid}}}");
+                if !line.contains(&pid_field)
+                    && !line.contains(&pid_field_end)
+                    && !line.contains(&pgid_field)
+                    && !line.contains(&pgid_field_end)
+                {
+                    continue;
+                }
+                let (destination, protocol) = match extract_seatbelt_destination(&line) {
+                    Some((dest, proto)) => (dest, proto),
+                    None => ("<unknown>".into(), "network".into()),
+                };
+                if let Err(e) = ctx.emit(AuditEvent::NetworkBlocked {
+                    timestamp: ctx.timestamp(),
+                    pid,
+                    destination: crate::audit::sanitize_audit_string(&destination),
+                    protocol: crate::audit::sanitize_audit_string(&protocol),
+                    detail: Some("seatbelt-deny".into()),
+                }) {
+                    log::error!("audit emit failed: {e}");
+                }
+            }
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[cfg_attr(windows, allow(dead_code))]
+    fn read_seatbelt_denials(&mut self, _pid: u32) {}
 
     /// Read resource usage from the agent's cgroup.
     ///
@@ -471,6 +597,43 @@ impl Drop for Process {
     }
 }
 
+/// Extract a network destination from a Seatbelt denial log line.
+#[cfg(any(target_os = "macos", test))]
+fn extract_seatbelt_destination(ndjson_line: &str) -> Option<(String, String)> {
+    let msg_start = ndjson_line.find("\"eventMessage\"")?;
+    let msg_area = &ndjson_line[msg_start..];
+
+    // Try unescaped addr "..." first, then JSON-escaped addr \"...\"
+    if let Some(addr_pos) = msg_area.find("addr \"") {
+        let start = addr_pos + 6;
+        let rest = &msg_area[start..];
+        if let Some(end) = rest.find('"') {
+            return Some((rest[..end].to_string(), "network".into()));
+        }
+    }
+    if let Some(addr_pos) = msg_area.find("addr \\\"") {
+        let start = addr_pos + 7;
+        let rest = &msg_area[start..];
+        if let Some(end) = rest.find("\\\"") {
+            return Some((rest[..end].to_string(), "network".into()));
+        }
+    }
+
+    for (proto_str, proto_name) in [("remote tcp ", "tcp"), ("remote udp ", "udp")] {
+        if let Some(pos) = msg_area.find(proto_str) {
+            let start = pos + proto_str.len();
+            let rest = &msg_area[start..];
+            let end = rest.find(['"', ')', ',']).unwrap_or(rest.len());
+            let addr = rest[..end].trim();
+            if !addr.is_empty() {
+                return Some((addr.to_string(), proto_name.into()));
+            }
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -493,6 +656,8 @@ mod tests {
                 cgroup_mgr: None,
                 #[cfg(target_os = "linux")]
                 dns_audit_pipe: None,
+                #[cfg(target_os = "macos")]
+                launch_timestamp: None,
                 #[cfg(all(target_os = "linux", feature = "microvm"))]
                 passt: None,
                 pty_master: None,
@@ -501,6 +666,46 @@ mod tests {
             };
         }
         assert!(!dir.exists(), "Drop should have removed the tmpdir");
+    }
+
+    #[test]
+    fn seatbelt_extract_addr_escaped() {
+        // macOS log show --style ndjson escapes quotes inside
+        // eventMessage as \". Test the escaped addr pattern.
+        let line = "{\"processID\":42,\"eventMessage\":\"deny(1) network-outbound addr \\\"1.2.3.4:443\\\"\"}";
+        let (dest, proto) = extract_seatbelt_destination(line).unwrap();
+        assert_eq!(dest, "1.2.3.4:443");
+        assert_eq!(proto, "network");
+    }
+
+    #[test]
+    fn seatbelt_extract_remote_tcp() {
+        let line =
+            r#"{"processID":42,"eventMessage":"deny(1) network-outbound remote tcp 10.0.0.1:80"}"#;
+        let (dest, proto) = extract_seatbelt_destination(line).unwrap();
+        assert_eq!(dest, "10.0.0.1:80");
+        assert_eq!(proto, "tcp");
+    }
+
+    #[test]
+    fn seatbelt_extract_remote_udp() {
+        let line =
+            r#"{"processID":42,"eventMessage":"deny(1) network-outbound remote udp 8.8.8.8:53"}"#;
+        let (dest, proto) = extract_seatbelt_destination(line).unwrap();
+        assert_eq!(dest, "8.8.8.8:53");
+        assert_eq!(proto, "udp");
+    }
+
+    #[test]
+    fn seatbelt_extract_no_match() {
+        let line = r#"{"processID":42,"eventMessage":"deny(1) file-read-data /etc/passwd"}"#;
+        assert!(extract_seatbelt_destination(line).is_none());
+    }
+
+    #[test]
+    fn seatbelt_extract_no_event_message() {
+        let line = r#"{"processID":42,"subsystem":"sandbox"}"#;
+        assert!(extract_seatbelt_destination(line).is_none());
     }
 
     #[cfg(all(target_os = "linux", feature = "serde"))]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -119,6 +119,17 @@ pub struct Profile {
     pub allow_exec: bool,
     /// Use CLONE_NEWNET for network namespace isolation (Linux only).
     pub use_netns: bool,
+    /// Enable DNS query capture inside the network namespace.
+    ///
+    /// When enabled, the bridge child runs a DNS server on UDP port 53
+    /// that intercepts queries, logs them as `NetworkBlocked` audit
+    /// events, and responds with NXDOMAIN.
+    ///
+    /// Requires `use_netns`, non-empty `read_paths` or `write_paths`
+    /// (so the wrapper binary is invoked), and mount namespace support
+    /// (`unshare --mount`). The `serde` Cargo feature is required for
+    /// NDJSON parsing of audit events.
+    pub dns_capture: bool,
     /// Seccomp filter profile. Defaults to Strict.
     pub seccomp_profile: SeccompProfile,
 }

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -192,6 +192,12 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
             ..Default::default()
         };
 
+        // Bind-mount resolv.conf when DNS capture is active.
+        if std::env::var("ARAPUCA_DNS_AUDIT_FD").is_ok() {
+            let ok = crate::wrapper::override_resolv_conf();
+            audit_layer(audit_fd, "ResolvConfOverride", ok, None);
+        }
+
         if let Err(e) = crate::landlock::apply(&profile) {
             audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
             write_stderr(&format!("arapuca: selfexec: landlock: {e}\n"));

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -204,7 +204,11 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
     // Fork a TCP-to-UDS relay child before seccomp is applied.
     match crate::bridge::parse_bridge_env() {
         Ok(Some((port, uds_path))) => {
-            match crate::bridge::fork_bridge(port, &uds_path) {
+            let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+                .ok()
+                .and_then(|s| s.parse::<i32>().ok())
+                .filter(|&fd| fd >= 0);
+            match crate::bridge::fork_bridge(port, &uds_path, dns_audit_fd) {
                 Ok(bridge_port) => {
                     let proxy = format!("http://127.0.0.1:{bridge_port}");
                     // SAFETY: single-threaded (Go runtime not started).
@@ -264,10 +268,16 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
     #[cfg(unix)]
     audit_layer(audit_fd, "Rlimit", true, None);
 
-    // ── Close audit FD before exec ───────────────────────────────
-    // MUST happen before execve — the parent's validate_wrapper_audit()
-    // blocks on read() until all write-end holders close the FD.
+    // ── Close audit FDs before exec ──────────────────────────────
+    // MUST happen before execve — the parent's pipe readers block on
+    // read() until all write-end holders close the FD.
     if let Some(fd) = audit_fd {
+        unsafe { libc::close(fd) };
+    }
+    if let Some(fd) = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+        .ok()
+        .and_then(|s| s.parse::<i32>().ok())
+    {
         unsafe { libc::close(fd) };
     }
 

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -214,7 +214,7 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                 .ok()
                 .and_then(|s| s.parse::<i32>().ok())
                 .filter(|&fd| fd >= 0);
-            match crate::bridge::fork_bridge(port, &uds_path, dns_audit_fd) {
+            match crate::bridge::fork_bridge(port, Some(&uds_path), dns_audit_fd) {
                 Ok(bridge_port) => {
                     let proxy = format!("http://127.0.0.1:{bridge_port}");
                     // SAFETY: single-threaded (Go runtime not started).
@@ -233,7 +233,24 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                 }
             }
         }
-        Ok(None) => {}
+        Ok(None) => {
+            let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+                .ok()
+                .and_then(|s| s.parse::<i32>().ok())
+                .filter(|&fd| fd >= 0);
+            if let Some(dns_fd) = dns_audit_fd {
+                match crate::bridge::fork_bridge(0, None, Some(dns_fd)) {
+                    Ok(_) => {
+                        audit_layer(audit_fd, "DnsCapture", true, None);
+                    }
+                    Err(e) => {
+                        audit_layer(audit_fd, "DnsCapture", false, Some(&e.to_string()));
+                        write_stderr(&format!("arapuca: selfexec: dns bridge: {e}\n"));
+                        unsafe { libc::_exit(1) };
+                    }
+                }
+            }
+        }
         Err(e) => {
             write_stderr(&format!("arapuca: selfexec: bridge env: {e}\n"));
             unsafe { libc::_exit(1) };

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -61,6 +61,83 @@ pub fn write_stderr(msg: &str) {
     let _ = unsafe { libc::write(2, msg.as_ptr().cast::<libc::c_void>(), msg.len()) };
 }
 
+/// Bind-mount a custom resolv.conf with `nameserver 127.0.0.1` over
+/// `/etc/resolv.conf` for DNS capture. Called inside the mount
+/// namespace before Landlock.
+///
+/// Uses PID in the temp filename to avoid races under concurrent
+/// launches. Remounts read-only after the bind mount.
+/// Returns true on success, false on failure.
+#[cfg(target_os = "linux")]
+pub fn override_resolv_conf() -> bool {
+    let tmpdir = std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".into());
+    let pid = std::process::id();
+    let path = format!("{tmpdir}/.arapuca-resolv-{pid}.conf");
+
+    // O_EXCL prevents symlink-following attacks on the temp file.
+    use std::io::Write;
+    let mut f = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(f) => f,
+        Err(_) => {
+            write_stderr("arapuca: failed to create resolv.conf override\n");
+            return false;
+        }
+    };
+    if f.write_all(b"nameserver 127.0.0.1\n").is_err() {
+        write_stderr("arapuca: failed to write resolv.conf override\n");
+        let _ = std::fs::remove_file(&path);
+        return false;
+    }
+    drop(f);
+
+    let src = match std::ffi::CString::new(path.as_str()) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let dst = match std::ffi::CString::new("/etc/resolv.conf") {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    let ret = unsafe {
+        libc::mount(
+            src.as_ptr(),
+            dst.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+    if ret != 0 {
+        write_stderr(&format!(
+            "arapuca: resolv.conf bind mount failed: {}\n",
+            std::io::Error::last_os_error()
+        ));
+        let _ = std::fs::remove_file(&path);
+        return false;
+    }
+
+    let ret = unsafe {
+        libc::mount(
+            std::ptr::null(),
+            dst.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND | libc::MS_REMOUNT | libc::MS_RDONLY,
+            std::ptr::null(),
+        )
+    };
+    if ret != 0 {
+        write_stderr("arapuca: resolv.conf remount-ro failed\n");
+    }
+
+    let _ = std::fs::remove_file(&path);
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/bridge.rs
+++ b/tests/bridge.rs
@@ -125,7 +125,7 @@ mod linux {
 
         let _echo = spawn_uds_echo(&uds_path);
 
-        let port = arapuca::bridge::fork_bridge(0, &uds_path, None).unwrap();
+        let port = arapuca::bridge::fork_bridge(0, Some(&uds_path), None).unwrap();
         assert!(port > 0, "fork_bridge should return a valid port");
 
         let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
@@ -172,7 +172,7 @@ mod linux {
         if child_pid == 0 {
             // Child: call fork_bridge, report port, then sleep.
             unsafe { libc::close(pipe_read) };
-            let port = match arapuca::bridge::fork_bridge(0, &uds_for_child, None) {
+            let port = match arapuca::bridge::fork_bridge(0, Some(&uds_for_child), None) {
                 Ok(p) => p,
                 Err(_) => unsafe { libc::_exit(2) },
             };

--- a/tests/bridge.rs
+++ b/tests/bridge.rs
@@ -55,6 +55,22 @@ mod linux {
         std::env::var("ARAPUCA_TEST_IN_NETNS").is_ok()
     }
 
+    fn build_dns_query(domain: &str, qtype: u16) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&[0x12, 0x34, 0x01, 0x00, 0x00, 0x01]);
+        buf.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        for label in domain.split('.') {
+            buf.push(label.len() as u8);
+            buf.extend_from_slice(label.as_bytes());
+        }
+        buf.push(0);
+        buf.push((qtype >> 8) as u8);
+        buf.push(qtype as u8);
+        buf.push(0x00);
+        buf.push(0x01);
+        buf
+    }
+
     /// Start a UDS echo server that copies input back to the client.
     /// Returns the join handle (runs until the client disconnects).
     fn spawn_uds_echo(path: &std::path::Path) -> std::thread::JoinHandle<()> {
@@ -225,5 +241,151 @@ mod linux {
         // Bridge grandchild should be dead — connection refused.
         let result = TcpStream::connect(("127.0.0.1", port));
         assert!(result.is_err(), "bridge should be dead after parent killed");
+    }
+
+    #[test]
+    fn fork_bridge_dns_capture() {
+        if in_netns() {
+            fork_bridge_dns_capture_inner();
+            return;
+        }
+        if !netns_root_available() {
+            eprintln!("skipping: unshare --user --net --map-root-user not available");
+            return;
+        }
+        reexec_in_netns("linux::fork_bridge_dns_capture");
+    }
+
+    fn fork_bridge_dns_capture_inner() {
+        let mut pipe_fds = [0i32; 2];
+        assert_eq!(
+            unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC) },
+            0
+        );
+        let pipe_read = pipe_fds[0];
+        let pipe_write = pipe_fds[1];
+
+        let port = arapuca::bridge::fork_bridge(0, None, Some(pipe_write)).unwrap();
+        assert_eq!(port, 0, "DNS-only mode should return port 0");
+
+        unsafe { libc::close(pipe_write) };
+
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let query = build_dns_query("evil.example.com", 1);
+        sock.send_to(&query, "127.0.0.1:53").unwrap();
+
+        sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        let mut buf = [0u8; 512];
+        let (n, _) = sock.recv_from(&mut buf).unwrap();
+        assert!(n >= 12, "response too short");
+        assert_ne!(buf[2] & 0x80, 0, "QR bit should be set (response)");
+        assert_eq!(buf[3] & 0x0F, 3, "RCODE should be NXDOMAIN (3)");
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let mut data = Vec::new();
+        unsafe {
+            let flags = libc::fcntl(pipe_read, libc::F_GETFL);
+            libc::fcntl(pipe_read, libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+        loop {
+            let mut tmp = [0u8; 1024];
+            let n = unsafe { libc::read(pipe_read, tmp.as_mut_ptr().cast(), tmp.len()) };
+            if n <= 0 {
+                break;
+            }
+            data.extend_from_slice(&tmp[..n as usize]);
+        }
+        unsafe { libc::close(pipe_read) };
+
+        let text = String::from_utf8_lossy(&data);
+        assert!(
+            text.contains("evil.example.com"),
+            "audit should contain domain, got: {text}"
+        );
+        assert!(
+            text.contains("\"qtype\":\"A\""),
+            "audit should contain qtype, got: {text}"
+        );
+    }
+
+    #[test]
+    fn fork_bridge_dns_with_relay() {
+        if in_netns() {
+            fork_bridge_dns_with_relay_inner();
+            return;
+        }
+        if !netns_root_available() {
+            eprintln!("skipping: unshare --user --net --map-root-user not available");
+            return;
+        }
+        reexec_in_netns("linux::fork_bridge_dns_with_relay");
+    }
+
+    fn fork_bridge_dns_with_relay_inner() {
+        let dir = tempfile::tempdir().unwrap();
+        let uds_path = dir.path().join("echo.sock");
+        let _echo = spawn_uds_echo(&uds_path);
+
+        let mut pipe_fds = [0i32; 2];
+        assert_eq!(
+            unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC) },
+            0
+        );
+        let pipe_read = pipe_fds[0];
+        let pipe_write = pipe_fds[1];
+
+        let port = arapuca::bridge::fork_bridge(0, Some(&uds_path), Some(pipe_write)).unwrap();
+        assert!(port > 0, "relay mode should return a valid port");
+
+        unsafe { libc::close(pipe_write) };
+
+        // Verify TCP relay works.
+        {
+            let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
+            client.write_all(b"relay test").unwrap();
+            client.shutdown(Shutdown::Write).unwrap();
+            let mut resp = Vec::new();
+            client.read_to_end(&mut resp).unwrap();
+            assert_eq!(resp, b"relay test");
+        }
+
+        // Verify DNS capture works alongside relay.
+        let sock = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+        let query = build_dns_query("test.example.org", 28);
+        sock.send_to(&query, "127.0.0.1:53").unwrap();
+
+        sock.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+        let mut buf = [0u8; 512];
+        let (n, _) = sock.recv_from(&mut buf).unwrap();
+        assert!(n >= 12);
+        assert_eq!(buf[3] & 0x0F, 3, "RCODE should be NXDOMAIN");
+
+        std::thread::sleep(Duration::from_millis(100));
+
+        let mut data = Vec::new();
+        unsafe {
+            let flags = libc::fcntl(pipe_read, libc::F_GETFL);
+            libc::fcntl(pipe_read, libc::F_SETFL, flags | libc::O_NONBLOCK);
+        }
+        loop {
+            let mut tmp = [0u8; 1024];
+            let n = unsafe { libc::read(pipe_read, tmp.as_mut_ptr().cast(), tmp.len()) };
+            if n <= 0 {
+                break;
+            }
+            data.extend_from_slice(&tmp[..n as usize]);
+        }
+        unsafe { libc::close(pipe_read) };
+
+        let text = String::from_utf8_lossy(&data);
+        assert!(
+            text.contains("test.example.org"),
+            "audit should contain domain, got: {text}"
+        );
+        assert!(
+            text.contains("\"qtype\":\"AAAA\""),
+            "audit should contain qtype, got: {text}"
+        );
     }
 }

--- a/tests/bridge.rs
+++ b/tests/bridge.rs
@@ -125,7 +125,7 @@ mod linux {
 
         let _echo = spawn_uds_echo(&uds_path);
 
-        let port = arapuca::bridge::fork_bridge(0, &uds_path).unwrap();
+        let port = arapuca::bridge::fork_bridge(0, &uds_path, None).unwrap();
         assert!(port > 0, "fork_bridge should return a valid port");
 
         let mut client = TcpStream::connect(("127.0.0.1", port)).unwrap();
@@ -172,7 +172,7 @@ mod linux {
         if child_pid == 0 {
             // Child: call fork_bridge, report port, then sleep.
             unsafe { libc::close(pipe_read) };
-            let port = match arapuca::bridge::fork_bridge(0, &uds_for_child) {
+            let port = match arapuca::bridge::fork_bridge(0, &uds_for_child, None) {
                 Ok(p) => p,
                 Err(_) => unsafe { libc::_exit(2) },
             };

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1021,3 +1021,106 @@ fn private_tmpdir_writable_but_slash_tmp_blocked() {
         "/tmp should be read-only by default: {stdout}"
     );
 }
+
+// ─── --deny-network tests ─────────────────────────────────────
+
+fn netns_root_available() -> bool {
+    Command::new("unshare")
+        .args(["--user", "--net", "--map-root-user", "--", "/bin/true"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+#[test]
+fn deny_network_resolv_conf_override() {
+    if !netns_root_available() {
+        eprintln!("skipping: unshare --user --net --map-root-user not available");
+        return;
+    }
+    let output = Command::new("unshare")
+        .args(["--user", "--net", "--mount", "--map-root-user", "--"])
+        .arg(arapuca_bin())
+        .args([
+            "run",
+            "--deny-network",
+            "--seccomp",
+            "baseline",
+            "--",
+            "/bin/sh",
+            "-c",
+            "cat /etc/resolv.conf",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "deny-network should succeed (exit {:?}):\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code(),
+    );
+    assert!(
+        stdout.contains("nameserver 127.0.0.1"),
+        "resolv.conf should be overridden to 127.0.0.1, got: {stdout}"
+    );
+}
+
+#[test]
+fn deny_network_dns_nxdomain() {
+    if !netns_root_available() {
+        eprintln!("skipping: unshare --user --net --map-root-user not available");
+        return;
+    }
+    let output = Command::new("unshare")
+        .args(["--user", "--net", "--mount", "--map-root-user", "--"])
+        .arg(arapuca_bin())
+        .args([
+            "run",
+            "--deny-network",
+            "--seccomp",
+            "baseline",
+            "--",
+            "/bin/sh",
+            "-c",
+            "nslookup example.com 2>&1; true",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "deny-network should succeed (exit {:?}):\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code(),
+    );
+    assert!(
+        stdout.contains("NXDOMAIN") || stdout.contains("server can't find"),
+        "DNS query should get NXDOMAIN, got: {stdout}"
+    );
+}
+
+#[test]
+fn deny_network_with_allow_host_rejected() {
+    let output = Command::new(arapuca_bin())
+        .args([
+            "run",
+            "--deny-network",
+            "--allow-host",
+            "example.com:443",
+            "--",
+            "/bin/true",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(125));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("mutually exclusive"),
+        "should reject combination, got: {stderr}"
+    );
+}


### PR DESCRIPTION
- Add AuditEvent::NetworkBlocked variant and SandboxLayer::DnsCapture for reporting blocked destinations
- Add minimal DNS wire format parser with label validation to prevent NDJSON injection
- Extend fork_bridge() with optional DNS capture server on UDP port 53, running in a dedicated thread NetworkBlocked events via serde_json parsing
- Add mount namespace support with resolv.conf bind-mount (read-only) to redirect sandbox DNS to the capture server
- Capture Seatbelt network-outbound denials on macOS via post-exit log show querying
- Support DNS-only bridge mode (no TCP relay) for --deny-network without --allow-host
- Add --deny-network CLI flag and reject --deny-network with --allow-host
- Add integration tests for DNS capture, pipe overflow, and --deny-network end-to-end