### PR TITLE
ffi: fix memory leak in arapuca_process_cleanup

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -454,13 +454,14 @@ int32_t arapuca_process_resource_stats(const struct arapuca_ArapucaProcess *proc
 uint32_t arapuca_process_oom_count(const struct arapuca_ArapucaProcess *proc);
 
 /**
- * Clean up the sandbox temp directory and cgroup.
+ * Clean up the sandbox temp directory, cgroup, and free the process handle.
+ * Safe to call with NULL.
  *
  * Must only be called after `arapuca_process_wait()` returns.
- * Consumes the process — subsequent calls on the same pointer are no-ops.
+ * The pointer is invalid after this call.
  *
  * # Safety
- * `proc` must be a valid pointer.
+ * `proc` must be NULL or a valid pointer from `arapuca_launch()`.
  */
 void arapuca_process_cleanup(struct arapuca_ArapucaProcess *proc);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -911,17 +911,19 @@ pub unsafe extern "C" fn arapuca_process_oom_count(proc_: *const ArapucaProcess)
     proc_.inner.as_ref().map_or(0, |p| p.oom_count())
 }
 
-/// Clean up the sandbox temp directory and cgroup.
+/// Clean up the sandbox temp directory, cgroup, and free the process handle.
+/// Safe to call with NULL.
 ///
 /// Must only be called after `arapuca_process_wait()` returns.
-/// Consumes the process — subsequent calls on the same pointer are no-ops.
+/// The pointer is invalid after this call.
 ///
 /// # Safety
-/// `proc` must be a valid pointer.
+/// `proc` must be NULL or a valid pointer from `arapuca_launch()`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn arapuca_process_cleanup(proc_: *mut ArapucaProcess) {
-    if let Some(proc_) = unsafe { proc_.as_mut() } {
-        if let Some(process) = proc_.inner.take() {
+    if !proc_.is_null() {
+        let mut p = unsafe { Box::from_raw(proc_) };
+        if let Some(process) = p.inner.take() {
             process.cleanup();
         }
     }


### PR DESCRIPTION
Use Box::from_raw to reclaim the ArapucaProcess allocation, matching the pattern used by the other three opaque-type free functions (profile_free, sandbox_free, config_free). The previous code used as_mut() which borrows the pointer without ever deallocating the Box, leaking memory on every launch+cleanup cycle.

Also update the doc comment and C header safety contract — the old comment promised "subsequent calls are no-ops" which is now UB (use-after-free) with Box::from_raw.

Fixes: #16 