### PR TITLE
Harden sandbox layers and fix unotify audit pipeline

### DIFF
--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -428,10 +428,7 @@ fn main() {
                             let mut msg = [0u8; 8];
                             msg[..4].copy_from_slice(&host_pid.to_ne_bytes());
                             msg[4..].copy_from_slice(&listener_fd.to_ne_bytes());
-                            let ret = unsafe {
-                                libc::write(fds.socketpair_parent, msg.as_ptr().cast(), msg.len())
-                            };
-                            if ret != msg.len() as isize {
+                            if !arapuca::unotify::write_all_raw(fds.socketpair_parent, &msg) {
                                 eprintln!(
                                     "arapuca: send unotify fd: {}",
                                     std::io::Error::last_os_error()

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -225,76 +225,10 @@ fn main() {
             audit_layer(audit_fd, "ResolvConfOverride", ok, None);
         }
 
-        let target = std::path::Path::new(&cmd);
-        if let Err(e) = arapuca::landlock::apply(&profile, Some(target)) {
-            audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
-            eprintln!("arapuca: landlock: {e}");
-            std::process::exit(1);
-        }
-        audit_layer(audit_fd, "Landlock", true, None);
-
-        // Bridge: fork a TCP-to-UDS relay before seccomp is applied.
-        // Activated when ARAPUCA_PROXY_BRIDGE=<port>:<uds_path> is set.
-        match arapuca::bridge::parse_bridge_env() {
-            Ok(Some((port, uds_path))) => {
-                let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
-                    .ok()
-                    .and_then(|s| s.parse::<i32>().ok())
-                    .filter(|&fd| fd >= 0);
-                let bridge_port = match arapuca::bridge::fork_bridge(
-                    port,
-                    Some(&uds_path),
-                    dns_audit_fd,
-                    seccomp_debug,
-                ) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        audit_layer(audit_fd, "ProxyBridge", false, Some(&e.to_string()));
-                        eprintln!("arapuca: bridge: {e}");
-                        std::process::exit(1);
-                    }
-                };
-                let proxy = format!("http://127.0.0.1:{bridge_port}");
-                // SAFETY: single-threaded at this point (between
-                // Landlock apply and seccomp apply, no threads spawned).
-                unsafe {
-                    std::env::set_var("HTTP_PROXY", &proxy);
-                    std::env::set_var("HTTPS_PROXY", &proxy);
-                    std::env::set_var("http_proxy", &proxy);
-                    std::env::set_var("https_proxy", &proxy);
-                }
-                audit_layer(audit_fd, "ProxyBridge", true, None);
-            }
-            Ok(None) => {
-                // DNS-only bridge: fork bridge for DNS capture without
-                // TCP relay when ARAPUCA_DNS_AUDIT_FD is set.
-                let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
-                    .ok()
-                    .and_then(|s| s.parse::<i32>().ok())
-                    .filter(|&fd| fd >= 0);
-                if let Some(dns_fd) = dns_audit_fd {
-                    match arapuca::bridge::fork_bridge(0, None, Some(dns_fd), seccomp_debug) {
-                        Ok(_) => {
-                            audit_layer(audit_fd, "DnsCapture", true, None);
-                        }
-                        Err(e) => {
-                            audit_layer(audit_fd, "DnsCapture", false, Some(&e.to_string()));
-                            eprintln!("arapuca: dns bridge: {e}");
-                            std::process::exit(1);
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!("arapuca: bridge: {e}");
-                std::process::exit(1);
-            }
-        }
-
         // ── Unotify supervisor ─────────────────────────────────
-        // Fork the supervisor BEFORE PID namespace and seccomp.
-        // The supervisor must be in the host PID namespace so
-        // /proc/<pid>/mem accesses the right process.
+        // Fork BEFORE Landlock, PID namespace, and seccomp.
+        // The supervisor reads /proc/<pid>/mem which Landlock
+        // excludes, and must be in the host PID namespace.
         #[cfg(seccomp_supported)]
         let unotify_config = arapuca::env::parse_unotify_config();
         #[cfg(seccomp_supported)]
@@ -337,6 +271,70 @@ fn main() {
                 None
             }
         };
+
+        let target = std::path::Path::new(&cmd);
+        if let Err(e) = arapuca::landlock::apply(&profile, Some(target)) {
+            audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
+            eprintln!("arapuca: landlock: {e}");
+            std::process::exit(1);
+        }
+        audit_layer(audit_fd, "Landlock", true, None);
+
+        // Bridge: fork a TCP-to-UDS relay before seccomp is applied.
+        // Activated when ARAPUCA_PROXY_BRIDGE=<port>:<uds_path> is set.
+        match arapuca::bridge::parse_bridge_env() {
+            Ok(Some((port, uds_path))) => {
+                let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+                    .ok()
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .filter(|&fd| fd >= 0);
+                let bridge_port = match arapuca::bridge::fork_bridge(
+                    port,
+                    Some(&uds_path),
+                    dns_audit_fd,
+                    seccomp_debug,
+                ) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        audit_layer(audit_fd, "ProxyBridge", false, Some(&e.to_string()));
+                        eprintln!("arapuca: bridge: {e}");
+                        std::process::exit(1);
+                    }
+                };
+                let proxy = format!("http://127.0.0.1:{bridge_port}");
+                unsafe {
+                    std::env::set_var("HTTP_PROXY", &proxy);
+                    std::env::set_var("HTTPS_PROXY", &proxy);
+                    std::env::set_var("http_proxy", &proxy);
+                    std::env::set_var("https_proxy", &proxy);
+                }
+                audit_layer(audit_fd, "ProxyBridge", true, None);
+            }
+            Ok(None) => {
+                // DNS-only bridge: fork bridge for DNS capture without
+                // TCP relay when ARAPUCA_DNS_AUDIT_FD is set.
+                let dns_audit_fd = std::env::var("ARAPUCA_DNS_AUDIT_FD")
+                    .ok()
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .filter(|&fd| fd >= 0);
+                if let Some(dns_fd) = dns_audit_fd {
+                    match arapuca::bridge::fork_bridge(0, None, Some(dns_fd), seccomp_debug) {
+                        Ok(_) => {
+                            audit_layer(audit_fd, "DnsCapture", true, None);
+                        }
+                        Err(e) => {
+                            audit_layer(audit_fd, "DnsCapture", false, Some(&e.to_string()));
+                            eprintln!("arapuca: dns bridge: {e}");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("arapuca: bridge: {e}");
+                std::process::exit(1);
+            }
+        }
 
         // PID namespace: unshare + fork between bridge and seccomp.
         // The parent (in host PID ns) stays as a signal relay; the

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -355,7 +355,8 @@ fn main() {
             audit_layer(audit_fd, "PidNamespace", true, None);
 
             // Parent never returns; child continues to seccomp.
-            arapuca::pidns::fork_into_pidns(audit_fd, dns_audit_fd, pid_report_fd);
+            let liveness_fd =
+                arapuca::pidns::fork_into_pidns(audit_fd, dns_audit_fd, pid_report_fd);
 
             // Child: re-set pdeathsig (fork clears it). The
             // getppid() race check is skipped inside the PID
@@ -367,6 +368,9 @@ fn main() {
                     std::io::Error::last_os_error()
                 );
                 unsafe { libc::_exit(1) };
+            }
+            if let Some(fd) = liveness_fd {
+                arapuca::pidns::check_parent_liveness(fd);
             }
         }
 

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -293,8 +293,9 @@ fn main() {
         // The supervisor must be in the host PID namespace so
         // /proc/<pid>/mem accesses the right process.
         #[cfg(seccomp_supported)]
+        let unotify_config = arapuca::env::parse_unotify_config();
+        #[cfg(seccomp_supported)]
         let unotify_fds = {
-            let unotify_config = arapuca::env::parse_unotify_config();
             if let Some(ref config) = unotify_config {
                 if arapuca::unotify::unotify_available() {
                     let unotify_audit_fd = std::env::var("ARAPUCA_UNOTIFY_AUDIT_FD")
@@ -397,7 +398,6 @@ fn main() {
             if arapuca::unotify::poll_readiness(fds.readiness_read, 5000).is_ok() {
                 unsafe { libc::close(fds.readiness_read) };
 
-                let unotify_config = arapuca::env::parse_unotify_config();
                 if let Some(ref config) = unotify_config {
                     let syscalls = arapuca::unotify::target_syscalls(
                         config.audit_file_access,

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -207,10 +207,12 @@ fn main() {
     {
         let read_paths = env_paths("ARAPUCA_READ_PATHS");
         let write_paths = env_paths("ARAPUCA_WRITE_PATHS");
+        let allow_exec = std::env::var("ARAPUCA_ALLOW_EXEC").as_deref() != Ok("0");
 
         let profile = arapuca::Profile {
             read_paths,
             write_paths,
+            allow_exec,
             ..Default::default()
         };
 
@@ -223,7 +225,8 @@ fn main() {
             audit_layer(audit_fd, "ResolvConfOverride", ok, None);
         }
 
-        if let Err(e) = arapuca::landlock::apply(&profile) {
+        let target = std::path::Path::new(&cmd);
+        if let Err(e) = arapuca::landlock::apply(&profile, Some(target)) {
             audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
             eprintln!("arapuca: landlock: {e}");
             std::process::exit(1);
@@ -1757,7 +1760,7 @@ fn fork_connect_proxy(
                     read_paths: proxy_read_paths,
                     ..Default::default()
                 };
-                if let Err(e) = arapuca::landlock::apply(&proxy_profile) {
+                if let Err(e) = arapuca::landlock::apply(&proxy_profile, None) {
                     eprintln!("arapuca: connect proxy: landlock: {e}");
                     unsafe { libc::_exit(1) };
                 }

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -407,9 +407,28 @@ fn main() {
                         .and_then(|bpf| arapuca::unotify::install_unotify_filter(&bpf))
                     {
                         Ok(listener_fd) => {
-                            let _ = arapuca::unotify::send_fd(fds.socketpair_parent, listener_fd);
+                            // Send the FD number via write() instead of
+                            // sendmsg(SCM_RIGHTS) — sendmsg is intercepted
+                            // by the USER_NOTIF filter we just installed.
+                            let fd_bytes = listener_fd.to_ne_bytes();
+                            let ret = unsafe {
+                                libc::write(
+                                    fds.socketpair_parent,
+                                    fd_bytes.as_ptr().cast(),
+                                    fd_bytes.len(),
+                                )
+                            };
+                            if ret != fd_bytes.len() as isize {
+                                eprintln!(
+                                    "arapuca: send unotify fd number: {}",
+                                    std::io::Error::last_os_error()
+                                );
+                                unsafe { libc::_exit(1) };
+                            }
+                            // Keep listener_fd open — supervisor duplicates
+                            // it via pidfd_getfd. CLOEXEC ensures it closes
+                            // on exec.
                             unsafe {
-                                libc::close(listener_fd);
                                 libc::close(fds.socketpair_parent);
                             }
                         }

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -347,6 +347,10 @@ fn main() {
                 .ok()
                 .and_then(|s| s.parse::<i32>().ok())
                 .filter(|&fd| fd >= 0);
+            let unotify_audit_fd: Option<i32> = std::env::var("ARAPUCA_UNOTIFY_AUDIT_FD")
+                .ok()
+                .and_then(|s| s.parse::<i32>().ok())
+                .filter(|&fd| fd >= 0);
 
             if let Err(e) = arapuca::pidns::unshare_pidns() {
                 audit_layer(audit_fd, "PidNamespace", false, Some(&e.to_string()));
@@ -356,8 +360,12 @@ fn main() {
             audit_layer(audit_fd, "PidNamespace", true, None);
 
             // Parent never returns; child continues to seccomp.
-            let liveness_fd =
-                arapuca::pidns::fork_into_pidns(audit_fd, dns_audit_fd, pid_report_fd);
+            let liveness_fd = arapuca::pidns::fork_into_pidns(
+                audit_fd,
+                dns_audit_fd,
+                unotify_audit_fd,
+                pid_report_fd,
+            );
 
             // Child: re-set pdeathsig (fork clears it). The
             // getppid() race check is skipped inside the PID

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -421,19 +421,19 @@ fn main() {
                     {
                         Ok(listener_fd) => {
                             // Send the FD number via write() instead of
-                            // sendmsg(SCM_RIGHTS) — sendmsg is intercepted
-                            // by the USER_NOTIF filter we just installed.
-                            let fd_bytes = listener_fd.to_ne_bytes();
+                            // Send host PID + listener FD number via
+                            // write() — sendmsg is intercepted by the
+                            // USER_NOTIF filter we just installed.
+                            let host_pid = arapuca::unotify::read_host_pid();
+                            let mut msg = [0u8; 8];
+                            msg[..4].copy_from_slice(&host_pid.to_ne_bytes());
+                            msg[4..].copy_from_slice(&listener_fd.to_ne_bytes());
                             let ret = unsafe {
-                                libc::write(
-                                    fds.socketpair_parent,
-                                    fd_bytes.as_ptr().cast(),
-                                    fd_bytes.len(),
-                                )
+                                libc::write(fds.socketpair_parent, msg.as_ptr().cast(), msg.len())
                             };
-                            if ret != fd_bytes.len() as isize {
+                            if ret != msg.len() as isize {
                                 eprintln!(
-                                    "arapuca: send unotify fd number: {}",
+                                    "arapuca: send unotify fd: {}",
                                     std::io::Error::last_os_error()
                                 );
                                 unsafe { libc::_exit(1) };

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -100,6 +100,23 @@ pub fn loopback_up() -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
 
+    // Timeout prevents hanging in doubly-nested user namespaces
+    // (e.g., rootless containers) where the kernel may not deliver
+    // the RTM_SETLINK ACK.
+    let tv = libc::timeval {
+        tv_sec: 3,
+        tv_usec: 0,
+    };
+    unsafe {
+        libc::setsockopt(
+            fd.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            &tv as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::timeval>() as libc::socklen_t,
+        );
+    }
+
     let mut resp = std::mem::MaybeUninit::<Response>::uninit();
 
     // SAFETY: fd is valid, resp is a stack-local buffer with correct
@@ -273,10 +290,12 @@ pub unsafe fn close_fds_except(keep: &[i32]) {
         return;
     }
 
-    // Last resort: brute-force close from 3 to sysconf(_SC_OPEN_MAX).
+    // Last resort: brute-force close from 3 to sysconf(_SC_OPEN_MAX),
+    // capped at 65536 to avoid hanging on systemd systems where
+    // _SC_OPEN_MAX returns ~1 billion (fs.nr_open).
     // SAFETY: sysconf(_SC_OPEN_MAX) returns the system FD limit.
     let max_fd = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) } as i32;
-    let limit = max_fd.min(4096);
+    let limit = if max_fd > 0 { max_fd.min(65536) } else { 4096 };
     for fd in 3..limit {
         if !keep.contains(&fd) {
             // SAFETY: closing an already-closed FD is harmless.

--- a/src/env.rs
+++ b/src/env.rs
@@ -356,12 +356,16 @@ pub fn wrapper_env(profile: &crate::Profile) -> crate::Result<Vec<(String, Strin
             profile.max_open_files.to_string(),
         ));
     }
-    // Always emit — never rely on absence encoding Strict.
+    // Always emit — never rely on absence encoding a default.
     // Linux::launch() calls env_clear() so ambient vars don't leak,
     // but defense-in-depth: explicit is better than implicit.
     env.push((
         "ARAPUCA_SECCOMP_PROFILE".into(),
         profile.seccomp_profile.as_str().into(),
+    ));
+    env.push((
+        "ARAPUCA_ALLOW_EXEC".into(),
+        if profile.allow_exec { "1" } else { "0" }.into(),
     ));
     if profile.seccomp_debug {
         env.push(("ARAPUCA_SECCOMP_DEBUG".into(), "1".into()));

--- a/src/env.rs
+++ b/src/env.rs
@@ -427,6 +427,9 @@ pub fn unotify_env(profile: &crate::Profile) -> Option<(String, String)> {
             parts.push("enforce".to_string());
         }
     }
+    if profile.dns_capture && profile.use_netns {
+        parts.push("dns_port=53".to_string());
+    }
     Some(("ARAPUCA_UNOTIFY_CONFIG".into(), parts.join(",")))
 }
 
@@ -437,6 +440,7 @@ pub fn parse_unotify_config() -> Option<crate::unotify::UnotifyConfig> {
     let mut audit_file_access = false;
     let mut audit_network = false;
     let mut bridge_port = None;
+    let mut dns_port = None;
     let mut enforce_network = false;
 
     for part in val.split(',') {
@@ -446,6 +450,9 @@ pub fn parse_unotify_config() -> Option<crate::unotify::UnotifyConfig> {
             "enforce" => enforce_network = true,
             s if s.starts_with("bridge_port=") => {
                 bridge_port = s.strip_prefix("bridge_port=").and_then(|p| p.parse().ok());
+            }
+            s if s.starts_with("dns_port=") => {
+                dns_port = s.strip_prefix("dns_port=").and_then(|p| p.parse().ok());
             }
             _ => {}
         }
@@ -459,6 +466,7 @@ pub fn parse_unotify_config() -> Option<crate::unotify::UnotifyConfig> {
         audit_file_access,
         audit_network,
         bridge_port,
+        dns_port,
         enforce_network,
     })
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1008,7 +1008,7 @@ pub unsafe extern "C" fn arapuca_apply(profile: *const ArapucaProfile) -> i32 {
         }
     }
     #[cfg(target_os = "linux")]
-    if let Err(e) = crate::landlock::apply(inner) {
+    if let Err(e) = crate::landlock::apply(inner, None) {
         set_error(&format!("landlock: {e}"));
         return -1;
     }

--- a/src/landlock.rs
+++ b/src/landlock.rs
@@ -5,17 +5,22 @@
 //! compatibility — unsupported access rights on older kernels are silently
 //! ignored, while core restrictions are always enforced.
 
+use std::path::Path;
+
 use landlock::{
-    ABI, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, make_bitflags,
-    path_beneath_rules,
+    ABI, Access, AccessFs, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr,
+    RulesetStatus, make_bitflags, path_beneath_rules,
 };
 
 use crate::{Error, Profile};
 
 /// Apply Landlock filesystem restrictions to the current process.
 ///
-/// This is called by the binary before `execve()`. After this call,
-/// the process can only access files within the allowed paths.
+/// `target_binary` is the resolved path to the command that will be
+/// `execve`-d after Landlock is applied. When `allow_exec` is false,
+/// Execute is stripped from all paths except the target binary and
+/// the ELF interpreter (needed for the wrapper's own execve and
+/// dynamic linking).
 ///
 /// # Errors
 ///
@@ -31,8 +36,18 @@ use crate::{Error, Profile};
 /// - Fail-closed: returns error if the ruleset is `NotEnforced`.
 ///   When both path lists are empty, applies a deny-all filesystem
 ///   policy (ruleset with zero rules) rather than skipping Landlock.
+///
+/// # Limitations
+///
+/// `dlopen()` from write paths is NOT blocked — Landlock Execute
+/// controls `execve` path resolution, not `mmap(PROT_EXEC)`.
+///
+/// The ELF interpreter grant creates a bypass: `ld.so /bin/sh` works
+/// because ld.so has Execute and loads targets via mmap. Robust exec
+/// blocking against command injection requires seccomp `execve`
+/// interception (future work).
 #[must_use = "landlock errors must be handled — the process may be unsandboxed"]
-pub fn apply(profile: &Profile) -> crate::Result<()> {
+pub fn apply(profile: &Profile, target_binary: Option<&Path>) -> crate::Result<()> {
     let read_paths = &profile.read_paths;
     let write_paths = &profile.write_paths;
 
@@ -44,14 +59,17 @@ pub fn apply(profile: &Profile) -> crate::Result<()> {
     // best-effort downgrade for access rights added in later ABIs.
     let abi = ABI::V5;
 
-    // All access rights we want to restrict.
-    let read_access = make_bitflags!(AccessFs::{
-        Execute
-        | ReadFile
-        | ReadDir
-    });
+    let read_access = if profile.allow_exec {
+        make_bitflags!(AccessFs::{ Execute | ReadFile | ReadDir })
+    } else {
+        make_bitflags!(AccessFs::{ ReadFile | ReadDir })
+    };
 
-    let write_access = AccessFs::from_all(abi);
+    let write_access = if profile.allow_exec {
+        AccessFs::from_all(abi)
+    } else {
+        AccessFs::from_all(abi) & !make_bitflags!(AccessFs::{ Execute })
+    };
 
     let mut ruleset = Ruleset::default()
         .handle_access(AccessFs::from_all(abi))
@@ -70,6 +88,29 @@ pub fn apply(profile: &Profile) -> crate::Result<()> {
     ruleset = ruleset
         .add_rules(write_rules)
         .map_err(|e| Error::Landlock(format!("add write rules: {e}")))?;
+
+    // When allow_exec is false, grant Execute only on the target
+    // binary and the ELF interpreter so the wrapper's execve and
+    // dynamic linking work.
+    if !profile.allow_exec {
+        let exec_read = make_bitflags!(AccessFs::{ Execute | ReadFile });
+        if let Some(binary) = target_binary {
+            if let Ok(fd) = PathFd::new(binary) {
+                let rule = PathBeneath::new(fd, exec_read);
+                ruleset = ruleset
+                    .add_rule(rule)
+                    .map_err(|e| Error::Landlock(format!("add exec rule (binary): {e}")))?;
+            }
+        }
+        if let Some(interp) = resolve_elf_interpreter(target_binary) {
+            if let Ok(fd) = PathFd::new(&interp) {
+                let rule = PathBeneath::new(fd, exec_read);
+                ruleset = ruleset
+                    .add_rule(rule)
+                    .map_err(|e| Error::Landlock(format!("add exec rule (ld.so): {e}")))?;
+            }
+        }
+    }
 
     // Enforce. set_no_new_privs(true) is the default and calls
     // prctl(PR_SET_NO_NEW_PRIVS) internally.
@@ -99,6 +140,84 @@ pub fn apply(profile: &Profile) -> crate::Result<()> {
         }
         RulesetStatus::NotEnforced => Err(Error::Landlock("ruleset not enforced".into())),
     }
+}
+
+/// Resolve the ELF interpreter path from the target binary's PT_INTERP
+/// program header. Falls back to well-known paths if reading fails.
+fn resolve_elf_interpreter(target: Option<&Path>) -> Option<std::path::PathBuf> {
+    if let Some(binary) = target {
+        if let Ok(mut file) = std::fs::File::open(binary) {
+            use std::io::Read;
+            let mut buf = vec![0u8; 4096];
+            let n = file.read(&mut buf).unwrap_or(0);
+            buf.truncate(n);
+            if let Some(interp) = parse_pt_interp(&buf) {
+                let p = std::path::PathBuf::from(interp);
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+    }
+
+    // Fallback to well-known paths.
+    #[cfg(target_arch = "x86_64")]
+    let fallback = "/lib64/ld-linux-x86-64.so.2";
+    #[cfg(target_arch = "aarch64")]
+    let fallback = "/lib/ld-linux-aarch64.so.1";
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let fallback = "";
+
+    let p = std::path::PathBuf::from(fallback);
+    if p.exists() { Some(p) } else { None }
+}
+
+/// Parse PT_INTERP from an ELF binary's program headers.
+fn parse_pt_interp(data: &[u8]) -> Option<String> {
+    // ELF magic: 0x7f 'E' 'L' 'F'
+    if data.len() < 64 || data[..4] != [0x7f, b'E', b'L', b'F'] {
+        return None;
+    }
+
+    let class = data[4]; // 1 = 32-bit, 2 = 64-bit
+    if class != 2 {
+        return None; // only 64-bit
+    }
+    if data[5] != 1 {
+        return None; // only little-endian
+    }
+
+    // e_phoff (offset 32, 8 bytes), e_phentsize (offset 54, 2 bytes),
+    // e_phnum (offset 56, 2 bytes).
+    let e_phoff = u64::from_le_bytes(data[32..40].try_into().ok()?) as usize;
+    let e_phentsize = u16::from_le_bytes(data[54..56].try_into().ok()?) as usize;
+    let e_phnum = u16::from_le_bytes(data[56..58].try_into().ok()?) as usize;
+
+    // PT_INTERP = 3
+    for i in 0..e_phnum {
+        let off = e_phoff.checked_add(i.checked_mul(e_phentsize)?)?;
+        if off.checked_add(e_phentsize)? > data.len() {
+            return None;
+        }
+        let p_type = u32::from_le_bytes(data[off..off + 4].try_into().ok()?);
+        if p_type == 3 {
+            // p_offset at offset 8 (8 bytes), p_filesz at offset 32 (8 bytes)
+            let p_offset = u64::from_le_bytes(data[off + 8..off + 16].try_into().ok()?) as usize;
+            let p_filesz = u64::from_le_bytes(data[off + 32..off + 40].try_into().ok()?) as usize;
+            let end = p_offset.checked_add(p_filesz)?;
+            if end > data.len() {
+                return None;
+            }
+            let segment = &data[p_offset..end];
+            // NUL-terminated string.
+            let end = segment
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(segment.len());
+            return String::from_utf8(segment[..end].to_vec()).ok();
+        }
+    }
+    None
 }
 
 /// Probe the Landlock ABI version supported by the running kernel.
@@ -132,7 +251,7 @@ mod tests {
     #[test]
     fn empty_paths_is_noop() {
         let profile = Profile::default();
-        assert!(apply(&profile).is_ok());
+        assert!(apply(&profile, None).is_ok());
     }
 
     #[test]

--- a/src/landlock.rs
+++ b/src/landlock.rs
@@ -78,12 +78,23 @@ pub fn apply(profile: &Profile) -> crate::Result<()> {
         .map_err(|e| Error::Landlock(format!("restrict self: {e}")))?;
 
     match status.ruleset {
-        RulesetStatus::FullyEnforced | RulesetStatus::PartiallyEnforced => {
-            log::info!(
-                "landlock: applied ({:?}, ABI {:?})",
-                status.ruleset,
-                abi_version()
-            );
+        RulesetStatus::FullyEnforced => {
+            log::info!("landlock: applied (FullyEnforced, ABI {:?})", abi_version());
+            Ok(())
+        }
+        RulesetStatus::PartiallyEnforced => {
+            let abi = abi_version();
+            let missing: &[&str] = match abi {
+                0..=1 => &["Refer", "Truncate", "IOCTL_DEV", "SCOPE_UNIX"],
+                2 => &["Truncate", "IOCTL_DEV", "SCOPE_UNIX"],
+                3 => &["IOCTL_DEV", "SCOPE_UNIX"],
+                4 => &["SCOPE_UNIX"],
+                _ => &[],
+            };
+            log::info!("landlock: applied (PartiallyEnforced, ABI {abi})");
+            if !missing.is_empty() {
+                log::warn!("landlock: ABI {abi} — not enforced: {}", missing.join(", "));
+            }
             Ok(())
         }
         RulesetStatus::NotEnforced => Err(Error::Landlock("ruleset not enforced".into())),

--- a/src/netns.rs
+++ b/src/netns.rs
@@ -1,6 +1,6 @@
 //! Network namespace isolation.
 //!
-//! Probes whether `unshare --user --net --map-current-user` is available
+//! Probes whether `unshare --user --net --map-root-user` is available
 //! on the current system. The actual namespace creation is done by the
 //! platform sandbox (Linux) when launching subprocesses.
 
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 /// Probe whether network namespace isolation works on this system.
 ///
-/// Runs `unshare --user --net --map-current-user -- /bin/true` as a
+/// Runs `unshare --user --net --map-root-user -- /bin/true` as a
 /// subprocess. Returns `true` if it succeeds, `false` otherwise.
 ///
 /// Some systems have the `unshare` binary but block the syscall via
@@ -17,7 +17,7 @@ use std::time::Duration;
 /// flags as the sandbox launch to ensure accuracy.
 pub fn available() -> bool {
     let result = Command::new("unshare")
-        .args(["--user", "--net", "--map-current-user", "--", "/bin/true"])
+        .args(["--user", "--net", "--map-root-user", "--", "/bin/true"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status();
@@ -30,7 +30,7 @@ pub fn available() -> bool {
 
 /// Probe whether mount namespace isolation works alongside netns.
 ///
-/// Tests `unshare --user --net --mount --map-current-user -- /bin/true`.
+/// Tests `unshare --user --net --mount --map-root-user -- /bin/true`.
 /// Required for DNS capture (bind-mounting resolv.conf). Falls back
 /// gracefully to netns-only if mount ns is unavailable.
 pub fn mount_ns_available() -> bool {
@@ -39,7 +39,7 @@ pub fn mount_ns_available() -> bool {
             "--user",
             "--net",
             "--mount",
-            "--map-current-user",
+            "--map-root-user",
             "--",
             "/bin/true",
         ])

--- a/src/pidns.rs
+++ b/src/pidns.rs
@@ -32,12 +32,13 @@ pub fn unshare_pidns() -> std::io::Result<()> {
 /// where the parent died between fork and prctl (see
 /// `check_parent_liveness`).
 ///
-/// `audit_fd` and `dns_audit_fd` are closed in the parent (so the
-/// orchestrator's audit pipe reader sees EOF). `pid_report_fd` is
-/// written with the child's host PID and closed.
+/// `audit_fd`, `dns_audit_fd`, and `unotify_audit_fd` are closed in
+/// the parent (so the orchestrator's pipe readers see EOF).
+/// `pid_report_fd` is written with the child's host PID and closed.
 pub fn fork_into_pidns(
     audit_fd: Option<i32>,
     dns_audit_fd: Option<i32>,
+    unotify_audit_fd: Option<i32>,
     pid_report_fd: Option<i32>,
 ) -> Option<i32> {
     // Liveness pipe: parent holds write end, child reads it after
@@ -82,7 +83,13 @@ pub fn fork_into_pidns(
     // on _exit, causing EOF on the child's read end.
 
     // This path never returns.
-    parent_relay(child_pid, audit_fd, dns_audit_fd, pid_report_fd);
+    parent_relay(
+        child_pid,
+        audit_fd,
+        dns_audit_fd,
+        unotify_audit_fd,
+        pid_report_fd,
+    );
 }
 
 /// Check the liveness pipe after `prctl(PR_SET_PDEATHSIG)`.
@@ -116,6 +123,7 @@ fn parent_relay(
     child_pid: i32,
     audit_fd: Option<i32>,
     dns_audit_fd: Option<i32>,
+    unotify_audit_fd: Option<i32>,
     pid_report_fd: Option<i32>,
 ) -> ! {
     // 1. Hold a pidfd to prevent the kernel from recycling the
@@ -146,6 +154,9 @@ fn parent_relay(
         unsafe { libc::close(fd) };
     }
     if let Some(fd) = dns_audit_fd {
+        unsafe { libc::close(fd) };
+    }
+    if let Some(fd) = unotify_audit_fd {
         unsafe { libc::close(fd) };
     }
 

--- a/src/pidns.rs
+++ b/src/pidns.rs
@@ -26,6 +26,12 @@ pub fn unshare_pidns() -> std::io::Result<()> {
 /// relays signals and exits with the child's status. The child
 /// returns normally so the caller can continue with seccomp + exec.
 ///
+/// Returns the read end of a liveness pipe. The parent holds the
+/// write end open until it exits. The child should check this FD
+/// after `prctl(PR_SET_PDEATHSIG)` to detect the TOCTOU race
+/// where the parent died between fork and prctl (see
+/// `check_parent_liveness`).
+///
 /// `audit_fd` and `dns_audit_fd` are closed in the parent (so the
 /// orchestrator's audit pipe reader sees EOF). `pid_report_fd` is
 /// written with the child's host PID and closed.
@@ -33,7 +39,19 @@ pub fn fork_into_pidns(
     audit_fd: Option<i32>,
     dns_audit_fd: Option<i32>,
     pid_report_fd: Option<i32>,
-) {
+) -> Option<i32> {
+    // Liveness pipe: parent holds write end, child reads it after
+    // prctl(PR_SET_PDEATHSIG) to detect if the parent already died.
+    // O_NONBLOCK so check_parent_liveness can read without fcntl.
+    let mut pipe_fds = [0i32; 2];
+    if unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) } != 0 {
+        write_stderr(&format!(
+            "arapuca: pidns liveness pipe: {}\n",
+            std::io::Error::last_os_error()
+        ));
+        unsafe { libc::_exit(1) };
+    }
+
     // SAFETY: single-threaded, no async-signal-unsafe state.
     let child_pid = unsafe { libc::fork() };
 
@@ -51,12 +69,45 @@ pub fn fork_into_pidns(
         if let Some(fd) = pid_report_fd {
             unsafe { libc::close(fd) };
         }
-        return;
+        // Close the liveness pipe write end — only the parent should
+        // hold it. Without this, EOF never fires on the read end.
+        unsafe { libc::close(pipe_fds[1]) };
+        return Some(pipe_fds[0]);
     }
 
     // ── Parent: signal relay + waitpid ────────────────────────────
+    // Close the liveness pipe read end (child's responsibility).
+    unsafe { libc::close(pipe_fds[0]) };
+    // Write end (pipe_fds[1]) is intentionally leaked — it closes
+    // on _exit, causing EOF on the child's read end.
+
     // This path never returns.
     parent_relay(child_pid, audit_fd, dns_audit_fd, pid_report_fd);
+}
+
+/// Check the liveness pipe after `prctl(PR_SET_PDEATHSIG)`.
+///
+/// A non-blocking read on the pipe's read end distinguishes:
+/// - `read() == 0` (EOF): parent already exited, pdeathsig won't
+///   fire — the child must exit immediately.
+/// - `read() == -1` with EAGAIN: write end still open, parent is
+///   alive — safe to continue.
+///
+/// Closes the FD after the check.
+pub fn check_parent_liveness(liveness_fd: i32) {
+    // The pipe was created with O_NONBLOCK, so no fcntl needed.
+    let mut buf = [0u8; 1];
+    let n = unsafe { libc::read(liveness_fd, buf.as_mut_ptr().cast(), 1) };
+    unsafe { libc::close(liveness_fd) };
+    if n == 0 {
+        // EOF: parent died before pdeathsig took effect.
+        write_stderr("arapuca: pidns: parent died before pdeathsig\n");
+        unsafe { libc::_exit(1) };
+    }
+    if n < 0 && std::io::Error::last_os_error().kind() != std::io::ErrorKind::WouldBlock {
+        write_stderr("arapuca: pidns: liveness check failed\n");
+        unsafe { libc::_exit(1) };
+    }
 }
 
 /// Parent relay loop. Writes child PID to the report pipe, closes

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -66,18 +66,28 @@ impl Darwin {
     ///
     /// This is a best-effort mechanism — the 500ms polling window means
     /// a process can briefly exceed the limit before being killed.
-    fn start_memory_monitor(pid: u32, limit_mb: u64) {
+    fn start_memory_monitor(
+        pid: u32,
+        limit_mb: u64,
+    ) -> Option<(
+        std::sync::Arc<std::sync::atomic::AtomicBool>,
+        std::thread::JoinHandle<()>,
+    )> {
         if limit_mb == 0 {
-            return;
+            return None;
         }
         let limit_kb = limit_mb * 1024;
-        std::thread::spawn(move || {
+        let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let cancel_clone = std::sync::Arc::clone(&cancel);
+        let handle = std::thread::spawn(move || {
             loop {
                 std::thread::sleep(std::time::Duration::from_millis(500));
 
+                if cancel_clone.load(std::sync::atomic::Ordering::Acquire) {
+                    break;
+                }
+
                 // Check if process still exists.
-                // SAFETY: kill with signal 0 checks process existence
-                // without sending a signal.
                 let alive = unsafe { libc::kill(pid as libc::pid_t, 0) } == 0;
                 if !alive {
                     break;
@@ -103,9 +113,6 @@ impl Darwin {
                         "memory limit exceeded: {rss_kb}KB > {limit_kb}KB, \
                          killing process group {pid}"
                     );
-                    // Kill the entire process group.
-                    // SAFETY: Sending SIGKILL to a process group. The
-                    // negative PID targets the group.
                     unsafe {
                         libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
                     }
@@ -113,6 +120,7 @@ impl Darwin {
                 }
             }
         });
+        Some((cancel, handle))
     }
 
     /// Start a parent-PID watchdog thread.
@@ -620,7 +628,11 @@ impl Sandbox for Darwin {
         }
 
         // Start memory monitor thread (best-effort RSS polling).
-        Self::start_memory_monitor(pid, cfg.profile.max_memory_mb);
+        let monitor = Self::start_memory_monitor(pid, cfg.profile.max_memory_mb);
+        let (monitor_cancel, monitor_handle) = match monitor {
+            Some((c, h)) => (Some(c), Some(h)),
+            None => (None, None),
+        };
 
         if let Some(ref ctx) = audit_ctx {
             let _ = ctx.emit(AuditEvent::LayerApplied {
@@ -653,6 +665,8 @@ impl Sandbox for Darwin {
             } else {
                 None
             },
+            monitor_cancel,
+            monitor_handle,
             audit_ctx,
             final_stats: None,
         })

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -163,12 +163,25 @@ impl Sandbox for Linux {
         } else {
             // Wrapper binary not available — no
             // Landlock/seccomp/rlimit/NO_NEW_PRIVS.
+            //
+            // On seccomp-supported architectures (x86_64, aarch64),
+            // always fail: the sandbox is meaningless without the
+            // wrapper applying Landlock + seccomp + rlimits.
+            // On other architectures, only fail if filesystem
+            // restrictions were explicitly requested.
+            if cfg!(seccomp_supported) {
+                return Err(Error::Process(
+                    "arapuca wrapper binary not found — refusing to launch \
+                     without Landlock/seccomp enforcement"
+                        .into(),
+                ));
+            }
             let has_paths =
                 !cfg.profile.read_paths.is_empty() || !cfg.profile.write_paths.is_empty();
             if has_paths {
                 return Err(Error::Process(
                     "filesystem restrictions requested but arapuca wrapper binary \
-                     not found — refusing to launch without Landlock/seccomp enforcement"
+                     not found"
                         .into(),
                 ));
             }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -550,8 +550,9 @@ impl Sandbox for Linux {
         // ── Unotify audit pipe ─────────────────────────────────────
         // When file access or network auditing is enabled, create a
         // pipe for the unotify supervisor to write NDJSON audit lines.
-        let unotify_wants =
-            (cfg.profile.audit_file_access || cfg.profile.audit_network) && use_wrapper;
+        let unotify_wants = (cfg.profile.audit_file_access || cfg.profile.audit_network)
+            && use_wrapper
+            && cfg!(feature = "serde");
         let unotify_audit_pipe = if unotify_wants {
             let mut fds = [0i32; 2];
             let ret = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
@@ -585,6 +586,10 @@ impl Sandbox for Linux {
             } else {
                 let reason = if !cfg.profile.audit_file_access && !cfg.profile.audit_network {
                     SkipReason::NotConfigured
+                } else if !cfg!(feature = "serde") {
+                    SkipReason::ComponentMissing(
+                        "serde feature required for unotify audit parsing".into(),
+                    )
                 } else if !use_wrapper {
                     SkipReason::ComponentMissing("wrapper binary not available".into())
                 } else {

--- a/src/process.rs
+++ b/src/process.rs
@@ -347,9 +347,14 @@ impl Process {
                 libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
             }
         }
+        const MAX_AUDIT_DRAIN: usize = 16 * 1024 * 1024;
         let mut data = Vec::new();
         let mut buf = [0u8; 4096];
         loop {
+            if data.len() >= MAX_AUDIT_DRAIN {
+                log::warn!("dns audit pipe: truncating at {MAX_AUDIT_DRAIN} bytes");
+                break;
+            }
             let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
             if n < 0 {
                 let err = std::io::Error::last_os_error();
@@ -406,9 +411,9 @@ impl Process {
                         if let Err(e) = ctx.emit(AuditEvent::NetworkBlocked {
                             timestamp: ctx.timestamp(),
                             pid,
-                            destination: entry.domain,
+                            destination: crate::audit::sanitize_audit_string(&entry.domain),
                             protocol: "dns".into(),
-                            detail: Some(entry.qtype),
+                            detail: Some(crate::audit::sanitize_audit_string(&entry.qtype)),
                         }) {
                             log::error!("audit emit failed: {e}");
                         }
@@ -464,9 +469,14 @@ impl Process {
             }
         }
 
+        const MAX_AUDIT_DRAIN: usize = 16 * 1024 * 1024;
         let mut data = Vec::new();
         let mut buf = [0u8; 4096];
         loop {
+            if data.len() >= MAX_AUDIT_DRAIN {
+                log::warn!("unotify audit pipe: truncating at {MAX_AUDIT_DRAIN} bytes");
+                break;
+            }
             let n = unsafe { libc::read(raw_fd, buf.as_mut_ptr().cast(), buf.len()) };
             if n > 0 {
                 data.extend_from_slice(&buf[..n as usize]);
@@ -526,19 +536,25 @@ impl Process {
                             "file_access" => ctx.emit(AuditEvent::FileAccess {
                                 timestamp: ctx.timestamp(),
                                 pid: event_pid,
-                                path: entry.path.unwrap_or_default(),
+                                path: crate::audit::sanitize_audit_string(
+                                    &entry.path.unwrap_or_default(),
+                                ),
                                 flags: entry.flags.unwrap_or(0),
                                 is_write: entry.is_write.unwrap_or(false),
                             }),
                             "process_spawn" => ctx.emit(AuditEvent::ProcessSpawn {
                                 timestamp: ctx.timestamp(),
                                 pid: event_pid,
-                                binary: entry.binary.unwrap_or_default(),
+                                binary: crate::audit::sanitize_audit_string(
+                                    &entry.binary.unwrap_or_default(),
+                                ),
                             }),
                             "network_blocked" => ctx.emit(AuditEvent::NetworkBlocked {
                                 timestamp: ctx.timestamp(),
                                 pid: event_pid,
-                                destination: entry.dest.unwrap_or_default(),
+                                destination: crate::audit::sanitize_audit_string(
+                                    &entry.dest.unwrap_or_default(),
+                                ),
                                 protocol: entry.protocol.unwrap_or_else(|| "tcp".into()),
                                 detail: Some("unotify".into()),
                             }),

--- a/src/process.rs
+++ b/src/process.rs
@@ -59,6 +59,12 @@ pub struct Process {
     /// Launch timestamp for macOS Seatbelt denial log querying.
     #[cfg(target_os = "macos")]
     pub(crate) launch_timestamp: Option<std::time::SystemTime>,
+    /// Cancellation flag for macOS memory monitor thread.
+    #[cfg(target_os = "macos")]
+    pub(crate) monitor_cancel: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    /// Join handle for macOS memory monitor thread.
+    #[cfg(target_os = "macos")]
+    pub(crate) monitor_handle: Option<std::thread::JoinHandle<()>>,
     /// Reference to the cgroup manager for stats/cleanup. Linux only.
     #[cfg(target_os = "linux")]
     pub(crate) cgroup_mgr: Option<std::sync::Arc<crate::cgroup::CgroupManager>>,
@@ -185,6 +191,38 @@ impl Process {
             return Err(crate::Error::Process("process already waited".into()));
         }
         let pid = self.pid();
+
+        // macOS: wait for child to exit without reaping (WNOWAIT),
+        // then cancel the memory monitor, join it, then reap.
+        // This prevents PID recycling between reap and monitor stop.
+        #[cfg(target_os = "macos")]
+        if self.monitor_cancel.is_some() {
+            let mut siginfo: libc::siginfo_t = unsafe { std::mem::zeroed() };
+            loop {
+                let ret = unsafe {
+                    libc::waitid(
+                        libc::P_PID,
+                        pid as libc::id_t,
+                        &mut siginfo,
+                        libc::WEXITED | libc::WNOWAIT,
+                    )
+                };
+                if ret == 0 {
+                    break;
+                }
+                if std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
+                    break;
+                }
+            }
+            // Child is dead but still a zombie — safe to stop monitor.
+            if let Some(cancel) = self.monitor_cancel.take() {
+                cancel.store(true, std::sync::atomic::Ordering::Release);
+            }
+            if let Some(handle) = self.monitor_handle.take() {
+                let _ = handle.join();
+            }
+        }
+
         let status = match &mut self.child {
             ChildHandle::Managed(c) => c
                 .wait()
@@ -484,6 +522,9 @@ impl Process {
                 break;
             } else {
                 let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
                 if err.kind() == std::io::ErrorKind::WouldBlock {
                     let mut pfd2 = libc::pollfd {
                         fd: raw_fd,
@@ -557,11 +598,13 @@ impl Process {
                                 destination: crate::audit::sanitize_audit_string(
                                     &entry.dest.unwrap_or_default(),
                                 ),
-                                protocol: entry
-                                    .syscall
-                                    .clone()
-                                    .or(entry.protocol)
-                                    .unwrap_or_else(|| "tcp".into()),
+                                protocol: crate::audit::sanitize_audit_string(
+                                    &entry
+                                        .syscall
+                                        .clone()
+                                        .or(entry.protocol)
+                                        .unwrap_or_else(|| "tcp".into()),
+                                ),
                                 detail: Some("unotify".into()),
                             }),
                             "dropped" => {
@@ -800,6 +843,18 @@ impl Process {
 
 impl Drop for Process {
     fn drop(&mut self) {
+        // macOS: cancel the memory monitor before killing/reaping
+        // the child to prevent PID recycling races.
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(cancel) = self.monitor_cancel.take() {
+                cancel.store(true, std::sync::atomic::Ordering::Release);
+            }
+            if let Some(handle) = self.monitor_handle.take() {
+                let _ = handle.join();
+            }
+        }
+
         // Kill the child process first to ensure resources can be
         // reclaimed. Without this, cgroups can't be destroyed while
         // occupied, and a live process would run unsupervised after
@@ -954,6 +1009,10 @@ mod tests {
                 waited: false,
                 #[cfg(target_os = "macos")]
                 launch_timestamp: None,
+                #[cfg(target_os = "macos")]
+                monitor_cancel: None,
+                #[cfg(target_os = "macos")]
+                monitor_handle: None,
                 #[cfg(all(target_os = "linux", feature = "microvm"))]
                 passt: None,
                 pty_master: None,
@@ -1051,6 +1110,10 @@ mod tests {
             waited: false,
             #[cfg(target_os = "macos")]
             launch_timestamp: None,
+            #[cfg(target_os = "macos")]
+            monitor_cancel: None,
+            #[cfg(target_os = "macos")]
+            monitor_handle: None,
             #[cfg(all(target_os = "linux", feature = "microvm"))]
             passt: None,
             pty_master: None,
@@ -1118,6 +1181,10 @@ mod tests {
             waited: false,
             #[cfg(target_os = "macos")]
             launch_timestamp: None,
+            #[cfg(target_os = "macos")]
+            monitor_cancel: None,
+            #[cfg(target_os = "macos")]
+            monitor_handle: None,
             #[cfg(all(target_os = "linux", feature = "microvm"))]
             passt: None,
             pty_master: None,
@@ -1161,6 +1228,10 @@ mod tests {
             waited: false,
             #[cfg(target_os = "macos")]
             launch_timestamp: None,
+            #[cfg(target_os = "macos")]
+            monitor_cancel: None,
+            #[cfg(target_os = "macos")]
+            monitor_handle: None,
             #[cfg(all(target_os = "linux", feature = "microvm"))]
             passt: None,
             pty_master: None,

--- a/src/process.rs
+++ b/src/process.rs
@@ -527,6 +527,8 @@ impl Process {
                     #[serde(default)]
                     protocol: Option<String>,
                     #[serde(default)]
+                    syscall: Option<String>,
+                    #[serde(default)]
                     count: Option<u64>,
                 }
                 match serde_json::from_str::<UnotifyLine>(line) {
@@ -555,7 +557,11 @@ impl Process {
                                 destination: crate::audit::sanitize_audit_string(
                                     &entry.dest.unwrap_or_default(),
                                 ),
-                                protocol: entry.protocol.unwrap_or_else(|| "tcp".into()),
+                                protocol: entry
+                                    .syscall
+                                    .clone()
+                                    .or(entry.protocol)
+                                    .unwrap_or_else(|| "tcp".into()),
                                 detail: Some("unotify".into()),
                             }),
                             "dropped" => {

--- a/src/process.rs
+++ b/src/process.rs
@@ -542,6 +542,14 @@ impl Process {
         }
         drop(owned_fd);
 
+        #[cfg(not(feature = "serde"))]
+        if !data.is_empty() {
+            log::warn!(
+                "unotify audit: {} bytes discarded (compile with 'serde' feature to emit events)",
+                data.len()
+            );
+        }
+
         #[cfg(feature = "serde")]
         if !data.is_empty() {
             let text = String::from_utf8_lossy(&data);

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -524,7 +524,7 @@ fn build_baseline_filter() -> crate::Result<BpfProgram> {
 
     // Stacked filter: block clone with namespace flags.
     // Default action = Allow (non-clone syscalls pass through).
-    // Match action = KillProcess (clone with ns flags is killed).
+    // Match action = Errno(EPERM) (clone with ns flags is denied).
     // We insert clone with a condition that matches when ANY
     // CLONE_NEW* flag is set. MaskedEq(CLONE_NEW_FLAGS, 0) matches
     // when no ns flags → we want the inverse.

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -367,9 +367,22 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                     crate::unotify::target_syscalls(config.audit_file_access, config.audit_network);
                 if let Ok(bpf) = crate::unotify::build_unotify_bpf(&syscalls) {
                     if let Ok(listener_fd) = crate::unotify::install_unotify_filter(&bpf) {
-                        let _ = crate::unotify::send_fd(fds.socketpair_parent, listener_fd);
+                        let fd_bytes = listener_fd.to_ne_bytes();
+                        let ret = unsafe {
+                            libc::write(
+                                fds.socketpair_parent,
+                                fd_bytes.as_ptr().cast(),
+                                fd_bytes.len(),
+                            )
+                        };
+                        if ret != fd_bytes.len() as isize {
+                            write_stderr(&format!(
+                                "arapuca: selfexec: send unotify fd number: {}\n",
+                                std::io::Error::last_os_error()
+                            ));
+                            unsafe { libc::_exit(1) };
+                        }
                         unsafe {
-                            libc::close(listener_fd);
                             libc::close(fds.socketpair_parent);
                         }
                     } else {

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -195,6 +195,46 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
         }
     }
 
+    // ── Unotify supervisor ────────────────────────────────────
+    // Fork BEFORE Landlock, PID namespace, and seccomp.
+    // The supervisor reads /proc/<pid>/mem which Landlock
+    // excludes, and must be in the host PID namespace.
+    #[cfg(seccomp_supported)]
+    let unotify_config = crate::env::parse_unotify_config();
+    #[cfg(seccomp_supported)]
+    let unotify_fds = {
+        if let Some(ref config) = unotify_config {
+            if crate::unotify::unotify_available() {
+                let unotify_audit_fd = std::env::var("ARAPUCA_UNOTIFY_AUDIT_FD")
+                    .ok()
+                    .and_then(|s| s.parse::<i32>().ok())
+                    .unwrap_or(-1);
+                if unotify_audit_fd >= 0 {
+                    match crate::unotify::fork_unotify_supervisor(
+                        config,
+                        unotify_audit_fd,
+                        seccomp_debug,
+                    ) {
+                        Ok(fds) => {
+                            audit_layer(audit_fd, "UnotifySupervisor", true, None);
+                            Some(fds)
+                        }
+                        Err(_) => {
+                            audit_layer(audit_fd, "UnotifySupervisor", false, None);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+
     // ── Landlock ─────────────────────────────────────────────────
     #[cfg(target_os = "linux")]
     {
@@ -274,43 +314,6 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
             unsafe { libc::_exit(1) };
         }
     }
-
-    // ── Unotify supervisor ────────────────────────────────────
-    #[cfg(seccomp_supported)]
-    let unotify_config = crate::env::parse_unotify_config();
-    #[cfg(seccomp_supported)]
-    let unotify_fds = {
-        if let Some(ref config) = unotify_config {
-            if crate::unotify::unotify_available() {
-                let unotify_audit_fd = std::env::var("ARAPUCA_UNOTIFY_AUDIT_FD")
-                    .ok()
-                    .and_then(|s| s.parse::<i32>().ok())
-                    .unwrap_or(-1);
-                if unotify_audit_fd >= 0 {
-                    match crate::unotify::fork_unotify_supervisor(
-                        config,
-                        unotify_audit_fd,
-                        seccomp_debug,
-                    ) {
-                        Ok(fds) => {
-                            audit_layer(audit_fd, "UnotifySupervisor", true, None);
-                            Some(fds)
-                        }
-                        Err(_) => {
-                            audit_layer(audit_fd, "UnotifySupervisor", false, None);
-                            None
-                        }
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    };
 
     // ── PID namespace ────────────────────────────────────────────
     if std::env::var("ARAPUCA_PID_NS").as_deref() == Ok("1") {

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -385,10 +385,7 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                         let mut msg = [0u8; 8];
                         msg[..4].copy_from_slice(&host_pid.to_ne_bytes());
                         msg[4..].copy_from_slice(&listener_fd.to_ne_bytes());
-                        let ret = unsafe {
-                            libc::write(fds.socketpair_parent, msg.as_ptr().cast(), msg.len())
-                        };
-                        if ret != msg.len() as isize {
+                        if !crate::unotify::write_all_raw(fds.socketpair_parent, &msg) {
                             write_stderr(&format!(
                                 "arapuca: selfexec: send unotify fd: {}\n",
                                 std::io::Error::last_os_error()

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -274,8 +274,9 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
 
     // ── Unotify supervisor ────────────────────────────────────
     #[cfg(seccomp_supported)]
+    let unotify_config = crate::env::parse_unotify_config();
+    #[cfg(seccomp_supported)]
     let unotify_fds = {
-        let unotify_config = crate::env::parse_unotify_config();
         if let Some(ref config) = unotify_config {
             if crate::unotify::unotify_available() {
                 let unotify_audit_fd = std::env::var("ARAPUCA_UNOTIFY_AUDIT_FD")
@@ -361,7 +362,6 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
     if let Some(ref fds) = unotify_fds {
         if crate::unotify::poll_readiness(fds.readiness_read, 5000).is_ok() {
             unsafe { libc::close(fds.readiness_read) };
-            let unotify_config = crate::env::parse_unotify_config();
             if let Some(ref config) = unotify_config {
                 let syscalls =
                     crate::unotify::target_syscalls(config.audit_file_access, config.audit_network);

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -324,6 +324,10 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
             .ok()
             .and_then(|s| s.parse::<i32>().ok())
             .filter(|&fd| fd >= 0);
+        let unotify_audit_fd: Option<i32> = std::env::var("ARAPUCA_UNOTIFY_AUDIT_FD")
+            .ok()
+            .and_then(|s| s.parse::<i32>().ok())
+            .filter(|&fd| fd >= 0);
 
         if let Err(e) = crate::pidns::unshare_pidns() {
             audit_layer(audit_fd, "PidNamespace", false, Some(&e.to_string()));
@@ -332,7 +336,8 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
         }
         audit_layer(audit_fd, "PidNamespace", true, None);
 
-        let liveness_fd = crate::pidns::fork_into_pidns(audit_fd, dns_audit_fd, pid_report_fd);
+        let liveness_fd =
+            crate::pidns::fork_into_pidns(audit_fd, dns_audit_fd, unotify_audit_fd, pid_report_fd);
 
         let ret = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
         if ret != 0 {

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -200,10 +200,12 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
     {
         let read_paths = env_paths_os("ARAPUCA_READ_PATHS");
         let write_paths = env_paths_os("ARAPUCA_WRITE_PATHS");
+        let allow_exec = std::env::var("ARAPUCA_ALLOW_EXEC").as_deref() != Ok("0");
 
         let profile = crate::Profile {
             read_paths,
             write_paths,
+            allow_exec,
             ..Default::default()
         };
 
@@ -213,7 +215,8 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
             audit_layer(audit_fd, "ResolvConfOverride", ok, None);
         }
 
-        if let Err(e) = crate::landlock::apply(&profile) {
+        let target = std::path::Path::new(&cmd);
+        if let Err(e) = crate::landlock::apply(&profile, Some(target)) {
             audit_layer(audit_fd, "Landlock", false, Some(&e.to_string()));
             write_stderr(&format!("arapuca: selfexec: landlock: {e}\n"));
             unsafe { libc::_exit(1) };

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -326,7 +326,7 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
         }
         audit_layer(audit_fd, "PidNamespace", true, None);
 
-        crate::pidns::fork_into_pidns(audit_fd, dns_audit_fd, pid_report_fd);
+        let liveness_fd = crate::pidns::fork_into_pidns(audit_fd, dns_audit_fd, pid_report_fd);
 
         let ret = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
         if ret != 0 {
@@ -335,6 +335,9 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                 std::io::Error::last_os_error()
             ));
             unsafe { libc::_exit(1) };
+        }
+        if let Some(fd) = liveness_fd {
+            crate::pidns::check_parent_liveness(fd);
         }
     }
 

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -381,17 +381,16 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                     crate::unotify::target_syscalls(config.audit_file_access, config.audit_network);
                 if let Ok(bpf) = crate::unotify::build_unotify_bpf(&syscalls) {
                     if let Ok(listener_fd) = crate::unotify::install_unotify_filter(&bpf) {
-                        let fd_bytes = listener_fd.to_ne_bytes();
+                        let host_pid = crate::unotify::read_host_pid();
+                        let mut msg = [0u8; 8];
+                        msg[..4].copy_from_slice(&host_pid.to_ne_bytes());
+                        msg[4..].copy_from_slice(&listener_fd.to_ne_bytes());
                         let ret = unsafe {
-                            libc::write(
-                                fds.socketpair_parent,
-                                fd_bytes.as_ptr().cast(),
-                                fd_bytes.len(),
-                            )
+                            libc::write(fds.socketpair_parent, msg.as_ptr().cast(), msg.len())
                         };
-                        if ret != fd_bytes.len() as isize {
+                        if ret != msg.len() as isize {
                             write_stderr(&format!(
-                                "arapuca: selfexec: send unotify fd number: {}\n",
+                                "arapuca: selfexec: send unotify fd: {}\n",
                                 std::io::Error::last_os_error()
                             ));
                             unsafe { libc::_exit(1) };

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -420,7 +420,7 @@ pub fn handle_notification(
             } else {
                 args[2] as u32
             };
-            let path = read_string(&mem, path_addr, 3900).unwrap_or_default();
+            let path = read_string(&mem, path_addr, 2000).unwrap_or_default();
             let is_write =
                 flags & (libc::O_WRONLY | libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC) as u32 != 0;
             write_audit_line(
@@ -428,7 +428,7 @@ pub fn handle_notification(
                 dropped,
                 &format!(
                     "{{\"type\":\"file_access\",\"pid\":{pid},\"path\":\"{}\",\"flags\":{flags},\"is_write\":{is_write}}}",
-                    crate::wrapper::json_escape(&path),
+                    escape_for_audit(&path),
                 ),
             );
             respond_continue(listener_fd, notif)
@@ -438,7 +438,7 @@ pub fn handle_notification(
             // open(pathname, flags, mode) — x86_64 only
             let path_addr = args[0];
             let flags = args[1] as u32;
-            let path = read_string(&mem, path_addr, 3900).unwrap_or_default();
+            let path = read_string(&mem, path_addr, 2000).unwrap_or_default();
             let is_write =
                 flags & (libc::O_WRONLY | libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC) as u32 != 0;
             write_audit_line(
@@ -446,7 +446,7 @@ pub fn handle_notification(
                 dropped,
                 &format!(
                     "{{\"type\":\"file_access\",\"pid\":{pid},\"path\":\"{}\",\"flags\":{flags},\"is_write\":{is_write}}}",
-                    crate::wrapper::json_escape(&path),
+                    escape_for_audit(&path),
                 ),
             );
             respond_continue(listener_fd, notif)
@@ -459,13 +459,13 @@ pub fn handle_notification(
             } else {
                 args[0]
             };
-            let binary = read_string(&mem, path_addr, 3900).unwrap_or_default();
+            let binary = read_string(&mem, path_addr, 2000).unwrap_or_default();
             write_audit_line(
                 audit_fd,
                 dropped,
                 &format!(
                     "{{\"type\":\"process_spawn\",\"pid\":{pid},\"binary\":\"{}\"}}",
-                    crate::wrapper::json_escape(&binary),
+                    escape_for_audit(&binary),
                 ),
             );
             respond_continue(listener_fd, notif)
@@ -544,7 +544,7 @@ pub fn handle_notification(
                                     dropped,
                                     &format!(
                                         "{{\"type\":\"network_blocked\",\"pid\":{pid},\"dest\":\"{}\",\"syscall\":\"sendmmsg\"}}",
-                                        crate::wrapper::json_escape(&info.destination),
+                                        escape_for_audit(&info.destination),
                                     ),
                                 );
                             }
@@ -597,7 +597,7 @@ fn handle_connect(
                     dropped,
                     &format!(
                         "{{\"type\":\"network_blocked\",\"pid\":{pid},\"dest\":\"{}\",\"syscall\":\"{syscall}\"}}",
-                        crate::wrapper::json_escape(&info.destination),
+                        escape_for_audit(&info.destination),
                     ),
                 );
                 if config.enforce_network {
@@ -755,6 +755,28 @@ fn respond_errno(listener_fd: RawFd, notif: &libc::seccomp_notif, errno: i32) ->
     notif_send(listener_fd, &resp).is_ok()
 }
 
+/// JSON-escape a string and cap it to fit in an audit line.
+///
+/// `json_escape` can expand input significantly: `\` → `\\` (2x),
+/// control chars → `\uXXXX` (6x). The escaped result is capped at
+/// `MAX_ESCAPED` chars to guarantee the formatted NDJSON line fits
+/// within PIPE_BUF.
+const MAX_ESCAPED: usize = 3900;
+
+fn escape_for_audit(s: &str) -> String {
+    let escaped = crate::wrapper::json_escape(s);
+    if escaped.len() <= MAX_ESCAPED {
+        return escaped;
+    }
+    let mut end = MAX_ESCAPED;
+    while end > 0 && !escaped.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = escaped[..end].to_string();
+    truncated.push_str("...");
+    truncated
+}
+
 /// Write an NDJSON audit line to the audit pipe.
 ///
 /// The audit pipe is O_NONBLOCK. On EAGAIN, increments the drop counter
@@ -768,25 +790,21 @@ fn write_audit_line(audit_fd: RawFd, dropped: &mut u64, line: &str) {
         if ret > 0 {
             *dropped = 0;
         }
-        // If this write also fails, keep accumulating.
     }
 
-    // Cap line length to fit within PIPE_BUF (4096) with the trailing
-    // newline. json_escape can expand paths significantly (each '\'
-    // doubles), so the formatted line may exceed PIPE_BUF. A partial
-    // write on O_NONBLOCK corrupts the NDJSON stream.
-    const MAX_LINE: usize = 4095; // 4096 - 1 for '\n'
-    let truncated = if line.len() > MAX_LINE {
-        let mut end = MAX_LINE;
-        while end > 0 && !line.is_char_boundary(end) {
-            end -= 1;
-        }
-        &line[..end]
-    } else {
-        line
-    };
+    // With escape_for_audit capping field values, the formatted line
+    // should always fit within PIPE_BUF (4096). Log a warning if it
+    // doesn't rather than writing broken JSON.
+    if line.len() > 4095 {
+        log::warn!(
+            "audit line exceeds PIPE_BUF ({} bytes), dropping",
+            line.len()
+        );
+        *dropped += 1;
+        return;
+    }
 
-    let data = format!("{truncated}\n");
+    let data = format!("{line}\n");
     let ret = unsafe { libc::write(audit_fd, data.as_ptr().cast(), data.len()) };
     if ret < 0 {
         let err = std::io::Error::last_os_error();

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -755,6 +755,42 @@ fn respond_errno(listener_fd: RawFd, notif: &libc::seccomp_notif, errno: i32) ->
     notif_send(listener_fd, &resp).is_ok()
 }
 
+/// Read exactly `buf.len()` bytes, retrying on EINTR and short reads.
+fn read_exact_raw(fd: RawFd, buf: &mut [u8]) -> bool {
+    let mut offset = 0;
+    while offset < buf.len() {
+        let n = unsafe { libc::read(fd, buf[offset..].as_mut_ptr().cast(), buf.len() - offset) };
+        if n > 0 {
+            offset += n as usize;
+        } else if n == 0 {
+            return false;
+        } else if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+/// Write exactly `buf.len()` bytes, retrying on EINTR and short writes.
+pub fn write_all_raw(fd: RawFd, buf: &[u8]) -> bool {
+    let mut offset = 0;
+    while offset < buf.len() {
+        let n = unsafe { libc::write(fd, buf[offset..].as_ptr().cast(), buf.len() - offset) };
+        if n > 0 {
+            offset += n as usize;
+        } else if n == 0 {
+            return false;
+        } else if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
 /// JSON-escape a string and cap it to fit in an audit line.
 ///
 /// `json_escape` can expand input significantly: `\` → `\\` (2x),
@@ -1129,11 +1165,13 @@ pub fn fork_unotify_supervisor(
         // the socketpair. The PID may differ from parent_pid when
         // pidns is active (the wrapper forks after the supervisor).
         let mut msg = [0u8; 8];
-        let ret = unsafe { libc::read(sp_child, msg.as_mut_ptr().cast(), 8) };
-        unsafe { libc::close(sp_child) };
-        if ret != 8 {
-            unsafe { libc::_exit(1) };
+        if !read_exact_raw(sp_child, &mut msg) {
+            unsafe {
+                libc::close(sp_child);
+                libc::_exit(1);
+            }
         }
+        unsafe { libc::close(sp_child) };
         let wrapper_pid = i32::from_ne_bytes(msg[..4].try_into().unwrap());
         let remote_fd = i32::from_ne_bytes(msg[4..].try_into().unwrap());
         let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, wrapper_pid, 0i32) } as i32;

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -545,6 +545,7 @@ pub fn handle_notification(
                 dropped,
                 args[1],
                 args[2],
+                "connect",
             )
         }
         libc::SYS_sendto => {
@@ -561,12 +562,21 @@ pub fn handle_notification(
                     dropped,
                     args[4],
                     args[5],
+                    "sendto",
                 )
             }
         }
         libc::SYS_sendmsg => {
             // sendmsg(sockfd, &msghdr, flags)
-            handle_sendmsg(listener_fd, notif, audit_fd, config, dropped, args[1])
+            handle_sendmsg(
+                listener_fd,
+                notif,
+                audit_fd,
+                config,
+                dropped,
+                args[1],
+                "sendmsg",
+            )
         }
         libc::SYS_sendmmsg => {
             // sendmmsg(sockfd, &mmsghdr_vec, vlen, flags)
@@ -595,7 +605,7 @@ pub fn handle_notification(
                                     audit_fd,
                                     dropped,
                                     &format!(
-                                        "{{\"type\":\"network_blocked\",\"pid\":{pid},\"dest\":\"{}\",\"protocol\":\"udp\"}}",
+                                        "{{\"type\":\"network_blocked\",\"pid\":{pid},\"dest\":\"{}\",\"syscall\":\"sendmmsg\"}}",
                                         crate::wrapper::json_escape(&info.destination),
                                     ),
                                 );
@@ -625,6 +635,7 @@ pub fn handle_notification(
 /// supervisor's read and the kernel's re-execution. Network blocking via
 /// unotify is defense-in-depth only — the network namespace (use_netns)
 /// is the primary security boundary.
+#[allow(clippy::too_many_arguments)]
 fn handle_connect(
     listener_fd: RawFd,
     notif: &libc::seccomp_notif,
@@ -633,6 +644,7 @@ fn handle_connect(
     dropped: &mut u64,
     addr: u64,
     addrlen: u64,
+    syscall: &str,
 ) -> bool {
     let pid = notif.pid;
 
@@ -645,7 +657,7 @@ fn handle_connect(
                     audit_fd,
                     dropped,
                     &format!(
-                        "{{\"type\":\"network_blocked\",\"pid\":{pid},\"dest\":\"{}\",\"protocol\":\"tcp\"}}",
+                        "{{\"type\":\"network_blocked\",\"pid\":{pid},\"dest\":\"{}\",\"syscall\":\"{syscall}\"}}",
                         crate::wrapper::json_escape(&info.destination),
                     ),
                 );
@@ -702,6 +714,7 @@ fn handle_sendmsg(
     config: &UnotifyConfig,
     dropped: &mut u64,
     msghdr_addr: u64,
+    syscall: &str,
 ) -> bool {
     let pid = notif.pid;
     // Read msg_name (pointer) and msg_namelen from msghdr.
@@ -719,6 +732,7 @@ fn handle_sendmsg(
             dropped,
             name_addr,
             namelen as u64,
+            syscall,
         ),
         _ => {
             // NULL msg_name or failed read — connected socket, allow.

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -1125,18 +1125,18 @@ pub fn fork_unotify_supervisor(
             libc::close(readiness_write);
         }
 
-        // Read the listener FD number from the socketpair, then
-        // duplicate it via pidfd_getfd. We use write/read instead of
-        // sendmsg/recvmsg (SCM_RIGHTS) because sendmsg is intercepted
-        // by the USER_NOTIF filter when audit_network is enabled.
-        let mut fd_bytes = [0u8; 4];
-        let ret = unsafe { libc::read(sp_child, fd_bytes.as_mut_ptr().cast(), 4) };
+        // Read the wrapper's host PID and listener FD number from
+        // the socketpair. The PID may differ from parent_pid when
+        // pidns is active (the wrapper forks after the supervisor).
+        let mut msg = [0u8; 8];
+        let ret = unsafe { libc::read(sp_child, msg.as_mut_ptr().cast(), 8) };
         unsafe { libc::close(sp_child) };
-        if ret != 4 {
+        if ret != 8 {
             unsafe { libc::_exit(1) };
         }
-        let remote_fd = i32::from_ne_bytes(fd_bytes);
-        let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, parent_pid, 0i32) } as i32;
+        let wrapper_pid = i32::from_ne_bytes(msg[..4].try_into().unwrap());
+        let remote_fd = i32::from_ne_bytes(msg[4..].try_into().unwrap());
+        let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, wrapper_pid, 0i32) } as i32;
         if pidfd < 0 {
             crate::wrapper::write_stderr("unotify supervisor: pidfd_open failed\n");
             unsafe { libc::_exit(1) };
@@ -1154,6 +1154,8 @@ pub fn fork_unotify_supervisor(
     }
 
     // ── Parent (wrapper) ─────────────────────────────────────
+    // (continues in the caller — install filter, write PID+FD,
+    // then proceed to exec)
     unsafe {
         libc::close(sp_child);
         libc::close(readiness_write);
@@ -1163,6 +1165,19 @@ pub fn fork_unotify_supervisor(
         socketpair_parent: sp_parent,
         readiness_read,
     })
+}
+
+/// Read the caller's host PID from `/proc/self/stat`.
+///
+/// Inside a PID namespace, `getpid()` returns the namespace-local
+/// PID (typically 1). This function reads the host PID from procfs,
+/// which always reflects the initial PID namespace where `/proc` is
+/// mounted.
+pub fn read_host_pid() -> i32 {
+    std::fs::read_to_string("/proc/self/stat")
+        .ok()
+        .and_then(|s| s.split_whitespace().next()?.parse().ok())
+        .unwrap_or_else(|| unsafe { libc::getpid() })
 }
 
 /// Apply the supervisor's own seccomp filter.

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -239,25 +239,54 @@ pub fn notif_id_valid(listener_fd: RawFd, id: u64) -> bool {
 
 // ─── /proc/<pid>/mem reader ────────────────────────────────────────
 
+/// RAII wrapper for a `/proc/<pid>/mem` file descriptor.
+///
+/// Opened once per notification and passed to all read helpers,
+/// avoiding repeated open/close cycles for the same PID.
+struct MemFd(RawFd);
+
+impl MemFd {
+    fn open(pid: u32) -> Option<Self> {
+        let mem_path = format!("/proc/{pid}/mem\0");
+        let fd = unsafe { libc::open(mem_path.as_ptr().cast(), libc::O_RDONLY | libc::O_CLOEXEC) };
+        if fd < 0 { None } else { Some(Self(fd)) }
+    }
+
+    fn pread(&self, buf: &mut [u8], offset: u64) -> isize {
+        unsafe {
+            libc::pread(
+                self.0,
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                offset as libc::off_t,
+            )
+        }
+    }
+
+    fn fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+impl Drop for MemFd {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.0) };
+    }
+}
+
 /// Read a NUL-terminated string from a target process's memory.
 ///
-/// Opens `/proc/<pid>/mem` and reads up to `max_len` bytes at `addr`,
-/// scanning for a NUL terminator. Returns `None` if the process exited,
-/// the address is unmapped, or the read fails for any reason.
-pub fn read_string_from_pid(pid: u32, addr: u64, max_len: usize) -> Option<String> {
+/// Reads up to `max_len` bytes at `addr` via the cached `MemFd`,
+/// scanning for a NUL terminator. Returns `None` if the address is
+/// NULL, unmapped, or the read fails for any reason.
+fn read_string(mem: &MemFd, addr: u64, max_len: usize) -> Option<String> {
     if addr == 0 {
-        return None;
-    }
-    let mem_path = format!("/proc/{pid}/mem\0");
-    let fd = unsafe { libc::open(mem_path.as_ptr().cast(), libc::O_RDONLY | libc::O_CLOEXEC) };
-    if fd < 0 {
         return None;
     }
 
     let cap = max_len.min(4096);
-    let mut buf = vec![0u8; cap];
-    let n = unsafe { libc::pread(fd, buf.as_mut_ptr().cast(), cap, addr as libc::off_t) };
-    unsafe { libc::close(fd) };
+    let mut buf = [0u8; 4096];
+    let n = mem.pread(&mut buf[..cap], addr);
 
     if n <= 0 {
         return None;
@@ -289,26 +318,20 @@ pub enum SockaddrResult {
     ReadFailed,
 }
 
-/// Wrapper around `read_sockaddr_from_pid` that returns a three-way result.
-pub fn read_sockaddr(pid: u32, addr: u64, addrlen: u64) -> SockaddrResult {
+/// Read a sockaddr from a target process's memory via the cached `MemFd`.
+fn read_sockaddr(mem: &MemFd, addr: u64, addrlen: u64) -> SockaddrResult {
     if addr == 0 || addrlen < 2 {
-        return SockaddrResult::ReadFailed;
-    }
-    let mem_path = format!("/proc/{pid}/mem\0");
-    let fd = unsafe { libc::open(mem_path.as_ptr().cast(), libc::O_RDONLY | libc::O_CLOEXEC) };
-    if fd < 0 {
         return SockaddrResult::ReadFailed;
     }
 
     let mut family_buf = [0u8; 2];
-    let n = unsafe { libc::pread(fd, family_buf.as_mut_ptr().cast(), 2, addr as libc::off_t) };
-    if n != 2 {
-        unsafe { libc::close(fd) };
+    if mem.pread(&mut family_buf, addr) != 2 {
         return SockaddrResult::ReadFailed;
     }
     let family = u16::from_ne_bytes(family_buf);
 
-    let result = match family as i32 {
+    let fd = mem.fd();
+    match family as i32 {
         libc::AF_INET if addrlen >= std::mem::size_of::<libc::sockaddr_in>() as u64 => {
             let mut sa: libc::sockaddr_in = unsafe { std::mem::zeroed() };
             let n = unsafe {
@@ -355,10 +378,7 @@ pub fn read_sockaddr(pid: u32, addr: u64, addrlen: u64) -> SockaddrResult {
         }
         libc::AF_INET | libc::AF_INET6 => SockaddrResult::ReadFailed, // addrlen too short
         _ => SockaddrResult::NonInet(family),
-    };
-
-    unsafe { libc::close(fd) };
-    result
+    }
 }
 
 // ─── Notification handler ─────────────────────────────────────────
@@ -367,9 +387,10 @@ const SYS_OPENAT2: i64 = 437;
 
 /// Handle a single seccomp notification.
 ///
-/// Dispatches by syscall number, reads arguments from `/proc/<pid>/mem`,
-/// writes an NDJSON audit line, and responds with either CONTINUE
-/// (observation) or ECONNREFUSED (network blocking).
+/// Opens `/proc/<pid>/mem` once and passes it to all read helpers,
+/// dispatches by syscall number, writes an NDJSON audit line, and
+/// responds with either CONTINUE (observation) or ECONNREFUSED
+/// (network blocking).
 ///
 /// Returns `true` if a response was sent, `false` if the notification
 /// was stale (target exited between recv and send).
@@ -384,6 +405,10 @@ pub fn handle_notification(
     let nr = notif.data.nr as i64;
     let args = &notif.data.args;
 
+    let Some(mem) = MemFd::open(pid) else {
+        return respond_continue(listener_fd, notif);
+    };
+
     match nr {
         libc::SYS_openat | SYS_OPENAT2 => {
             // openat(dirfd, pathname, flags, mode)
@@ -391,12 +416,11 @@ pub fn handle_notification(
             let path_addr = args[1];
             let flags = if nr == SYS_OPENAT2 {
                 // open_how.flags is the first field (u64)
-                // Read it from /proc/<pid>/mem at args[2]
-                read_u64_from_pid(pid, args[2]).unwrap_or(0) as u32
+                read_u64(&mem, args[2]).unwrap_or(0) as u32
             } else {
                 args[2] as u32
             };
-            let path = read_string_from_pid(pid, path_addr, 3900).unwrap_or_default();
+            let path = read_string(&mem, path_addr, 3900).unwrap_or_default();
             let is_write =
                 flags & (libc::O_WRONLY | libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC) as u32 != 0;
             write_audit_line(
@@ -414,7 +438,7 @@ pub fn handle_notification(
             // open(pathname, flags, mode) — x86_64 only
             let path_addr = args[0];
             let flags = args[1] as u32;
-            let path = read_string_from_pid(pid, path_addr, 3900).unwrap_or_default();
+            let path = read_string(&mem, path_addr, 3900).unwrap_or_default();
             let is_write =
                 flags & (libc::O_WRONLY | libc::O_RDWR | libc::O_CREAT | libc::O_TRUNC) as u32 != 0;
             write_audit_line(
@@ -435,7 +459,7 @@ pub fn handle_notification(
             } else {
                 args[0]
             };
-            let binary = read_string_from_pid(pid, path_addr, 3900).unwrap_or_default();
+            let binary = read_string(&mem, path_addr, 3900).unwrap_or_default();
             write_audit_line(
                 audit_fd,
                 dropped,
@@ -451,6 +475,7 @@ pub fn handle_notification(
             handle_connect(
                 listener_fd,
                 notif,
+                &mem,
                 audit_fd,
                 config,
                 dropped,
@@ -468,6 +493,7 @@ pub fn handle_notification(
                 handle_connect(
                     listener_fd,
                     notif,
+                    &mem,
                     audit_fd,
                     config,
                     dropped,
@@ -482,6 +508,7 @@ pub fn handle_notification(
             handle_sendmsg(
                 listener_fd,
                 notif,
+                &mem,
                 audit_fd,
                 config,
                 dropped,
@@ -495,7 +522,6 @@ pub fn handle_notification(
             // respond_continue resumes the entire batch.
             // sizeof(struct mmsghdr) = 64 on LP64 (msghdr=56 + msg_len=4 + pad=4).
             const MAX_SENDMMSG_INSPECT: u64 = 64;
-            let pid = notif.pid;
             if args[2] > MAX_SENDMMSG_INSPECT && config.enforce_network {
                 return respond_errno(listener_fd, notif, libc::ECONNREFUSED);
             }
@@ -504,13 +530,14 @@ pub fn handle_notification(
             let mut block = false;
             for i in 0..vlen {
                 let msghdr_addr = args[1] + i * MMSGHDR_SIZE;
-                if sendmsg_should_block(pid, msghdr_addr, config) {
+                if sendmsg_should_block(&mem, msghdr_addr, config) {
                     // Emit audit event for this blocked destination.
-                    let msg_name = read_u64_from_pid(pid, msghdr_addr);
-                    let msg_namelen = read_u32_from_pid(pid, msghdr_addr + 8);
+                    let msg_name = read_u64(&mem, msghdr_addr);
+                    let msg_namelen = read_u32(&mem, msghdr_addr + 8);
                     if let (Some(addr), Some(len)) = (msg_name, msg_namelen) {
                         if addr != 0 && len > 0 {
-                            if let SockaddrResult::Inet(info) = read_sockaddr(pid, addr, len as u64)
+                            if let SockaddrResult::Inet(info) =
+                                read_sockaddr(&mem, addr, len as u64)
                             {
                                 write_audit_line(
                                     audit_fd,
@@ -550,6 +577,7 @@ pub fn handle_notification(
 fn handle_connect(
     listener_fd: RawFd,
     notif: &libc::seccomp_notif,
+    mem: &MemFd,
     audit_fd: RawFd,
     config: &UnotifyConfig,
     dropped: &mut u64,
@@ -559,7 +587,7 @@ fn handle_connect(
 ) -> bool {
     let pid = notif.pid;
 
-    match read_sockaddr(pid, addr, addrlen) {
+    match read_sockaddr(mem, addr, addrlen) {
         SockaddrResult::Inet(info) => {
             if is_bridge_addr(&info, config) {
                 respond_continue(listener_fd, notif)
@@ -595,20 +623,19 @@ fn handle_connect(
     }
 }
 
-/// Handle sendmsg: extract msg_name from msghdr.
 /// Check if a msghdr's destination address should be blocked.
 ///
 /// Returns true if the destination is a non-bridge INET address
 /// (i.e., would be blocked by network enforcement). Does NOT emit
 /// a seccomp response — the caller must respond after checking all
 /// messages in a batch.
-fn sendmsg_should_block(pid: u32, msghdr_addr: u64, config: &UnotifyConfig) -> bool {
-    let msg_name = read_u64_from_pid(pid, msghdr_addr);
-    let msg_namelen = read_u32_from_pid(pid, msghdr_addr + 8);
+fn sendmsg_should_block(mem: &MemFd, msghdr_addr: u64, config: &UnotifyConfig) -> bool {
+    let msg_name = read_u64(mem, msghdr_addr);
+    let msg_namelen = read_u32(mem, msghdr_addr + 8);
 
     match (msg_name, msg_namelen) {
         (Some(name_addr), Some(namelen)) if name_addr != 0 && namelen > 0 => {
-            match read_sockaddr(pid, name_addr, namelen as u64) {
+            match read_sockaddr(mem, name_addr, namelen as u64) {
                 SockaddrResult::Inet(info) => !is_bridge_addr(&info, config),
                 SockaddrResult::NonInet(_) => false,
                 SockaddrResult::ReadFailed => config.enforce_network,
@@ -618,26 +645,28 @@ fn sendmsg_should_block(pid: u32, msghdr_addr: u64, config: &UnotifyConfig) -> b
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_sendmsg(
     listener_fd: RawFd,
     notif: &libc::seccomp_notif,
+    mem: &MemFd,
     audit_fd: RawFd,
     config: &UnotifyConfig,
     dropped: &mut u64,
     msghdr_addr: u64,
     syscall: &str,
 ) -> bool {
-    let pid = notif.pid;
     // Read msg_name (pointer) and msg_namelen from msghdr.
     // struct msghdr { void *msg_name; socklen_t msg_namelen; ... }
     // On 64-bit: msg_name at offset 0 (8 bytes), msg_namelen at offset 8 (4 bytes).
-    let msg_name = read_u64_from_pid(pid, msghdr_addr);
-    let msg_namelen = read_u32_from_pid(pid, msghdr_addr + 8);
+    let msg_name = read_u64(mem, msghdr_addr);
+    let msg_namelen = read_u32(mem, msghdr_addr + 8);
 
     match (msg_name, msg_namelen) {
         (Some(name_addr), Some(namelen)) if name_addr != 0 && namelen > 0 => handle_connect(
             listener_fd,
             notif,
+            mem,
             audit_fd,
             config,
             dropped,
@@ -670,50 +699,30 @@ fn is_bridge_addr(info: &SockaddrInfo, config: &UnotifyConfig) -> bool {
     false
 }
 
-/// Read a u64 from a target process's memory.
-fn read_u64_from_pid(pid: u32, addr: u64) -> Option<u64> {
+/// Read a u64 from a target process's memory via the cached `MemFd`.
+fn read_u64(mem: &MemFd, addr: u64) -> Option<u64> {
     if addr == 0 {
         return None;
     }
-    let mem_path = format!("/proc/{pid}/mem\0");
-    let fd = unsafe { libc::open(mem_path.as_ptr().cast(), libc::O_RDONLY | libc::O_CLOEXEC) };
-    if fd < 0 {
-        return None;
+    let mut buf = [0u8; 8];
+    if mem.pread(&mut buf, addr) == 8 {
+        Some(u64::from_ne_bytes(buf))
+    } else {
+        None
     }
-    let mut val = 0u64;
-    let n = unsafe {
-        libc::pread(
-            fd,
-            &mut val as *mut u64 as *mut libc::c_void,
-            8,
-            addr as libc::off_t,
-        )
-    };
-    unsafe { libc::close(fd) };
-    if n == 8 { Some(val) } else { None }
 }
 
-/// Read a u32 from a target process's memory.
-fn read_u32_from_pid(pid: u32, addr: u64) -> Option<u32> {
+/// Read a u32 from a target process's memory via the cached `MemFd`.
+fn read_u32(mem: &MemFd, addr: u64) -> Option<u32> {
     if addr == 0 {
         return None;
     }
-    let mem_path = format!("/proc/{pid}/mem\0");
-    let fd = unsafe { libc::open(mem_path.as_ptr().cast(), libc::O_RDONLY | libc::O_CLOEXEC) };
-    if fd < 0 {
-        return None;
+    let mut buf = [0u8; 4];
+    if mem.pread(&mut buf, addr) == 4 {
+        Some(u32::from_ne_bytes(buf))
+    } else {
+        None
     }
-    let mut val = 0u32;
-    let n = unsafe {
-        libc::pread(
-            fd,
-            &mut val as *mut u32 as *mut libc::c_void,
-            4,
-            addr as libc::off_t,
-        )
-    };
-    unsafe { libc::close(fd) };
-    if n == 4 { Some(val) } else { None }
 }
 
 // ─── Response helpers ─────────────────────────────────────────────

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -8,8 +8,10 @@
 //!
 //! The supervisor is forked BEFORE any seccomp filters are installed
 //! (to avoid inheriting the USER_NOTIF filter, which would deadlock
-//! on the supervisor's own `openat` calls). The listener FD is passed
-//! to the supervisor via `SCM_RIGHTS` after filter installation.
+//! on the supervisor's own `openat` calls). The listener FD number is
+//! sent via `write()` on a socketpair; the supervisor duplicates it
+//! via `pidfd_getfd`. This avoids `sendmsg` (SCM_RIGHTS) which would
+//! be intercepted by the USER_NOTIF filter.
 //!
 //! Requires kernel ≥ 5.5 (`SECCOMP_USER_NOTIF_FLAG_CONTINUE`).
 
@@ -43,9 +45,9 @@ const SECCOMP_IOCTL_NOTIF_RECV: libc::c_ulong = ioc(IOC_WRITE | IOC_READ, 0, 80)
 const SECCOMP_IOCTL_NOTIF_SEND: libc::c_ulong = ioc(IOC_WRITE | IOC_READ, 1, 24);
 
 /// `ioctl(fd, SECCOMP_IOCTL_NOTIF_ID_VALID, &id)` — check if notification is still valid.
-/// Kernel 5.17+ uses `_IOWR`; kernels 5.0–5.16 use `_IOR`. The 5.17+
+/// Kernel 5.17+ uses `_IOW`; kernels 5.0–5.16 use `_IOR`. The 5.17+
 /// kernel accepts both, so we try the new one first and fall back.
-const SECCOMP_IOCTL_NOTIF_ID_VALID_NEW: libc::c_ulong = ioc(IOC_WRITE | IOC_READ, 2, 8);
+const SECCOMP_IOCTL_NOTIF_ID_VALID_NEW: libc::c_ulong = ioc(IOC_WRITE, 2, 8);
 const SECCOMP_IOCTL_NOTIF_ID_VALID_OLD: libc::c_ulong = ioc(IOC_READ, 2, 8);
 
 // ─── BPF construction ─────────────────────────────────────────────
@@ -225,105 +227,14 @@ pub fn notif_id_valid(listener_fd: RawFd, id: u64) -> bool {
     if ret == 0 {
         return true;
     }
-    if std::io::Error::last_os_error().raw_os_error() == Some(libc::ENOTTY) {
+    let errno = std::io::Error::last_os_error().raw_os_error();
+    if errno == Some(libc::ENOTTY) || errno == Some(libc::EINVAL) {
         id_mut = id;
         let ret =
             unsafe { libc::ioctl(listener_fd, SECCOMP_IOCTL_NOTIF_ID_VALID_OLD, &mut id_mut) };
         return ret == 0;
     }
     false
-}
-
-// ─── SCM_RIGHTS helpers ───────────────────────────────────────────
-
-/// Send a file descriptor over a Unix socket using SCM_RIGHTS.
-pub fn send_fd(socket_fd: RawFd, fd_to_send: RawFd) -> std::io::Result<()> {
-    let iov = libc::iovec {
-        iov_base: b"\x00" as *const u8 as *mut libc::c_void,
-        iov_len: 1,
-    };
-
-    // cmsg buffer: header + one i32 FD
-    let cmsg_space = unsafe { libc::CMSG_SPACE(std::mem::size_of::<i32>() as u32) } as usize;
-    let mut cmsg_buf = vec![0u8; cmsg_space];
-
-    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
-    msg.msg_iov = &iov as *const libc::iovec as *mut libc::iovec;
-    msg.msg_iovlen = 1;
-    msg.msg_control = cmsg_buf.as_mut_ptr().cast();
-    msg.msg_controllen = cmsg_space as _;
-
-    // SAFETY: CMSG_FIRSTHDR on a valid msghdr with allocated control buffer.
-    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
-    if cmsg.is_null() {
-        return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
-    }
-    unsafe {
-        (*cmsg).cmsg_level = libc::SOL_SOCKET;
-        (*cmsg).cmsg_type = libc::SCM_RIGHTS;
-        (*cmsg).cmsg_len = libc::CMSG_LEN(std::mem::size_of::<i32>() as u32) as usize;
-        std::ptr::copy_nonoverlapping(
-            &fd_to_send as *const i32 as *const u8,
-            libc::CMSG_DATA(cmsg),
-            std::mem::size_of::<i32>(),
-        );
-    }
-
-    let ret = unsafe { libc::sendmsg(socket_fd, &msg, 0) };
-    if ret < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    Ok(())
-}
-
-/// Receive a file descriptor from a Unix socket using SCM_RIGHTS.
-///
-/// Blocks until the FD is received.
-pub fn recv_fd(socket_fd: RawFd) -> std::io::Result<RawFd> {
-    let mut byte = [0u8; 1];
-    let mut iov = libc::iovec {
-        iov_base: byte.as_mut_ptr().cast(),
-        iov_len: 1,
-    };
-
-    let cmsg_space = unsafe { libc::CMSG_SPACE(std::mem::size_of::<i32>() as u32) } as usize;
-    let mut cmsg_buf = vec![0u8; cmsg_space];
-
-    let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
-    msg.msg_iov = &mut iov;
-    msg.msg_iovlen = 1;
-    msg.msg_control = cmsg_buf.as_mut_ptr().cast();
-    msg.msg_controllen = cmsg_space as _;
-
-    let ret = unsafe { libc::recvmsg(socket_fd, &mut msg, 0) };
-    if ret < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-    if ret == 0 {
-        return Err(std::io::Error::from_raw_os_error(libc::ECONNRESET));
-    }
-
-    let cmsg = unsafe { libc::CMSG_FIRSTHDR(&msg) };
-    if cmsg.is_null() {
-        return Err(std::io::Error::from_raw_os_error(libc::ENODATA));
-    }
-    unsafe {
-        if (*cmsg).cmsg_level != libc::SOL_SOCKET || (*cmsg).cmsg_type != libc::SCM_RIGHTS {
-            return Err(std::io::Error::from_raw_os_error(libc::ENODATA));
-        }
-        let mut fd: i32 = -1;
-        std::ptr::copy_nonoverlapping(
-            libc::CMSG_DATA(cmsg),
-            &mut fd as *mut i32 as *mut u8,
-            std::mem::size_of::<i32>(),
-        );
-        if fd < 0 {
-            return Err(std::io::Error::from_raw_os_error(libc::EBADF));
-        }
-        // Set CLOEXEC on the received FD.
-        libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
-        Ok(fd)
-    }
 }
 
 // ─── /proc/<pid>/mem reader ────────────────────────────────────────
@@ -741,16 +652,22 @@ fn handle_sendmsg(
     }
 }
 
-/// Check if a sockaddr points to the bridge address.
+/// Check if a sockaddr points to the bridge or DNS capture address.
 fn is_bridge_addr(info: &SockaddrInfo, config: &UnotifyConfig) -> bool {
-    let Some(bridge_port) = config.bridge_port else {
-        return false;
-    };
-    if info.port != bridge_port {
+    if !info.destination.starts_with("127.0.0.1:") {
         return false;
     }
-    // Bridge is always on 127.0.0.1.
-    info.destination.starts_with("127.0.0.1:")
+    if let Some(bridge_port) = config.bridge_port {
+        if info.port == bridge_port {
+            return true;
+        }
+    }
+    if let Some(dns_port) = config.dns_port {
+        if info.port == dns_port {
+            return true;
+        }
+    }
+    false
 }
 
 /// Read a u64 from a target process's memory.
@@ -1021,6 +938,8 @@ pub struct UnotifyConfig {
     pub audit_network: bool,
     /// Bridge port to allow through (127.0.0.1:<port>).
     pub bridge_port: Option<u16>,
+    /// DNS capture port to allow through (127.0.0.1:<port>).
+    pub dns_port: Option<u16>,
     /// When true, block non-bridge INET connections with ECONNREFUSED.
     /// When false, log connections and allow them through (audit-only).
     /// Should only be true when `use_netns` is active (netns is the
@@ -1056,10 +975,10 @@ pub struct UnotifyFds {
 /// 1. Poll `readiness_read` (confirms supervisor is alive)
 /// 2. Install normal seccomp filters
 /// 3. Install USER_NOTIF filter LAST → get listener FD
-/// 4. Send listener FD via `send_fd(socketpair_parent, listener_fd)`
-/// 5. Close socketpair_parent + listener_fd
+/// 4. Write listener FD number via `write(socketpair_parent, &fd)`
+/// 5. Close socketpair_parent (keep listener_fd for pidfd_getfd)
 ///
-/// The supervisor blocks on `recv_fd` until step 4 completes.
+/// The supervisor reads the FD number, duplicates it via pidfd_getfd.
 ///
 /// `audit_write_fd` is the write end of the audit pipe (created by
 /// the library, passed via ARAPUCA_UNOTIFY_AUDIT_FD).
@@ -1109,6 +1028,7 @@ pub fn fork_unotify_supervisor(
         audit_file_access: config.audit_file_access,
         audit_network: config.audit_network,
         bridge_port: config.bridge_port,
+        dns_port: config.dns_port,
         enforce_network: config.enforce_network,
     };
 
@@ -1178,12 +1098,29 @@ pub fn fork_unotify_supervisor(
             libc::close(readiness_write);
         }
 
-        // Block until the caller sends the listener FD.
-        let listener_fd = match recv_fd(sp_child) {
-            Ok(fd) => fd,
-            Err(_) => unsafe { libc::_exit(1) },
-        };
+        // Read the listener FD number from the socketpair, then
+        // duplicate it via pidfd_getfd. We use write/read instead of
+        // sendmsg/recvmsg (SCM_RIGHTS) because sendmsg is intercepted
+        // by the USER_NOTIF filter when audit_network is enabled.
+        let mut fd_bytes = [0u8; 4];
+        let ret = unsafe { libc::read(sp_child, fd_bytes.as_mut_ptr().cast(), 4) };
         unsafe { libc::close(sp_child) };
+        if ret != 4 {
+            unsafe { libc::_exit(1) };
+        }
+        let remote_fd = i32::from_ne_bytes(fd_bytes);
+        let pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, parent_pid, 0i32) } as i32;
+        if pidfd < 0 {
+            crate::wrapper::write_stderr("unotify supervisor: pidfd_open failed\n");
+            unsafe { libc::_exit(1) };
+        }
+        let listener_fd =
+            unsafe { libc::syscall(libc::SYS_pidfd_getfd, pidfd, remote_fd, 0u32) } as i32;
+        unsafe { libc::close(pidfd) };
+        if listener_fd < 0 {
+            crate::wrapper::write_stderr("unotify supervisor: pidfd_getfd failed\n");
+            unsafe { libc::_exit(1) };
+        }
 
         // Enter the supervisor loop (never returns).
         supervisor_loop(listener_fd, audit_write_fd, &child_config);
@@ -1206,7 +1143,8 @@ pub fn fork_unotify_supervisor(
 /// Derived from the bridge's allowlist (bridge.rs:build_bridge_filters)
 /// but tailored for the supervisor's workload: ioctl (for seccomp
 /// notification recv/send/id_valid), openat+pread64 (for /proc/pid/mem),
-/// recvmsg (for SCM_RIGHTS), and standard runtime syscalls.
+/// pidfd_open+pidfd_getfd (for listener FD transfer), and standard
+/// runtime syscalls.
 #[cfg(seccomp_supported)]
 fn apply_supervisor_seccomp(debug: bool) -> crate::Result<()> {
     if debug {
@@ -1220,7 +1158,8 @@ fn apply_supervisor_seccomp(debug: bool) -> crate::Result<()> {
     let arch = crate::seccomp::target_arch()?;
     let mut allow: HashMap<i64, Vec<SeccompRule>> = HashMap::new();
 
-    // I/O: /proc/<pid>/mem reading, audit pipe writing, socketpair recv.
+    // I/O: /proc/<pid>/mem reading, audit pipe writing, socketpair recv,
+    // pidfd_open+pidfd_getfd for listener FD transfer.
     for nr in [
         libc::SYS_openat,
         libc::SYS_read,
@@ -1229,9 +1168,10 @@ fn apply_supervisor_seccomp(debug: bool) -> crate::Result<()> {
         libc::SYS_close,
         libc::SYS_writev,
         libc::SYS_lseek,
-        libc::SYS_recvmsg,
         libc::SYS_ppoll,
         libc::SYS_fcntl,
+        libc::SYS_pidfd_open,
+        libc::SYS_pidfd_getfd,
     ] {
         allow.insert(nr, vec![]);
     }
@@ -1562,55 +1502,13 @@ mod tests {
     }
 
     #[test]
-    fn scm_rights_round_trip() {
-        // Create a socketpair, send a pipe FD through it, verify receipt.
-        let mut sv = [0i32; 2];
-        let ret = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, sv.as_mut_ptr()) };
-        assert_eq!(ret, 0, "socketpair failed");
-
-        // Create a pipe to use as the FD to send.
-        let mut pipe_fds = [0i32; 2];
-        let ret = unsafe { libc::pipe(pipe_fds.as_mut_ptr()) };
-        assert_eq!(ret, 0, "pipe failed");
-
-        // Send pipe read end through the socketpair.
-        send_fd(sv[0], pipe_fds[0]).expect("send_fd failed");
-
-        // Receive it on the other end.
-        let received_fd = recv_fd(sv[1]).expect("recv_fd failed");
-        assert!(received_fd >= 0, "received FD should be valid");
-        assert_ne!(
-            received_fd, pipe_fds[0],
-            "received FD should be a new descriptor"
-        );
-
-        // Verify it's actually the same pipe: write on write-end, read on received.
-        let msg = b"hello";
-        let written = unsafe { libc::write(pipe_fds[1], msg.as_ptr().cast(), msg.len()) };
-        assert_eq!(written, 5);
-
-        let mut buf = [0u8; 5];
-        let read = unsafe { libc::read(received_fd, buf.as_mut_ptr().cast(), buf.len()) };
-        assert_eq!(read, 5);
-        assert_eq!(&buf, b"hello");
-
-        // Cleanup.
-        unsafe {
-            libc::close(sv[0]);
-            libc::close(sv[1]);
-            libc::close(pipe_fds[0]);
-            libc::close(pipe_fds[1]);
-            libc::close(received_fd);
-        }
-    }
-
-    #[test]
     fn unotify_config_any_enabled() {
         assert!(
             !UnotifyConfig {
                 audit_file_access: false,
                 audit_network: false,
                 bridge_port: None,
+                dns_port: None,
                 enforce_network: false,
             }
             .any_enabled()
@@ -1620,6 +1518,7 @@ mod tests {
                 audit_file_access: true,
                 audit_network: false,
                 bridge_port: None,
+                dns_port: None,
                 enforce_network: false,
             }
             .any_enabled()
@@ -1629,6 +1528,7 @@ mod tests {
                 audit_file_access: false,
                 audit_network: true,
                 bridge_port: Some(8080),
+                dns_port: None,
                 enforce_network: true,
             }
             .any_enabled()

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -856,7 +856,7 @@ fn probe_unotify_support() -> bool {
     // Phase 1: Check that we can read a sibling process's /proc/<pid>/mem.
     // This catches Yama ptrace_scope=1 without a user namespace.
     if !probe_proc_mem_access() {
-        log::info!("unotify: /proc/<pid>/mem access blocked (Yama ptrace_scope?)");
+        log::info!("unotify: /proc/<pid>/mem access blocked (Landlock, Yama, or LSM restriction)");
         return false;
     }
 


### PR DESCRIPTION
Harden Landlock, seccomp, pidns, and bridge components, and fix the unotify supervisor lifecycle so FileAccess and ProcessSpawn events are emitted correctly.