### PR TITLE
fix: use --map-root-user when netns + proxy bridge are both enabled

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -208,7 +208,20 @@ impl Sandbox for Linux {
         // ── Network namespace ──────────────────────────────────────
         let mut command = if cfg.profile.use_netns {
             let mut c = Command::new("unshare");
-            c.args(["--user", "--net", "--map-current-user", "--"]);
+            // When a proxy bridge is configured, the wrapper's bridge child
+            // needs to bring up the loopback interface via netlink
+            // (RTM_SETLINK / IFF_UP), which requires CAP_NET_ADMIN inside the
+            // network namespace. `--map-root-user` maps the current UID to
+            // uid 0 *within the user namespace only*, granting CAP_NET_ADMIN
+            // over the net namespace without any host privileges.
+            // Without it, `loopback_up()` fails with EPERM and the bridge
+            // cannot relay TCP connections into the sandbox.
+            let user_flag = if cfg.network_proxy_socket.is_some() {
+                "--map-root-user"
+            } else {
+                "--map-current-user"
+            };
+            c.args(["--user", "--net", user_flag, "--"]);
             c.arg(&actual_cmd);
             c.args(&actual_args);
             if let Some(ref ctx) = audit_ctx {


### PR DESCRIPTION
Fixes #22.

## Problem

When `NetworkProxySocket` is set alongside `UseNetNS`, the wrapper binary forks a bridge child that calls `loopback_up()` to bring up the loopback interface via netlink (`RTM_SETLINK`). This requires `CAP_NET_ADMIN` inside the network namespace.

With `--map-current-user`, the process gets no network capabilities and `loopback_up()` fails:
```
arapuca: bridge: loopback: Operation not permitted (os error 1)
```

## Fix

Use `--map-root-user` instead of `--map-current-user` when `network_proxy_socket` is set. This maps the current UID to uid 0 *within the user namespace only* — granting `CAP_NET_ADMIN` over the newly created network namespace without any elevated privileges on the host.

```rust
let user_flag = if cfg.network_proxy_socket.is_some() {
    "--map-root-user"
} else {
    "--map-current-user"
};
```

## Verification

Tested end-to-end with go-arapuca:
- `loopback_up()` succeeds inside the netns
- TCP bridge on `127.0.0.1:18080` accepts connections
- Full relay chain: TCP inside netns → Unix socket → host HTTP proxy works
- External network (host-side) remains fully isolated
- All 44 tests pass (1 pre-existing failure unrelated to this change)