### PR TITLE
ffi: expose arapuca_profile_set_seccomp for Baseline profile selection

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -208,11 +208,40 @@ void arapuca_profile_set_max_open_files(struct arapuca_ArapucaProfile *profile, 
 void arapuca_profile_set_netns(struct arapuca_ArapucaProfile *profile, bool enabled);
 
 /**
+ * Set the seccomp profile for the sandboxed process.
+ *
+ * `profile_str` must be a null-terminated string: `"strict"` (default)
+ * or `"baseline"`. Strict blocks AF_INET/AF_INET6, memfd_create,
+ * io_uring, and other advanced syscalls. Baseline blocks only
+ * sandbox-escape syscalls and is designed for trusted-but-isolated
+ * applications such as Claude Code that need full POSIX syscall
+ * access. Returns 0 on success, -1 if the profile string is invalid.
+ *
+ * # Safety
+ * `profile` and `profile_str` must be valid pointers.
+ */
+int32_t arapuca_profile_set_seccomp(struct arapuca_ArapucaProfile *profile,
+                                    const char *profile_str);
+
+/**
+ * Enable or disable PID namespace isolation.
+ *
+ * When enabled, the sandboxed process runs in an isolated PID
+ * namespace where it cannot see or signal host processes.
+ * Requires a user namespace (provided by netns or added
+ * automatically).
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_pidns(struct arapuca_ArapucaProfile *profile, bool enabled);
+
+/**
  * Enable DNS query capture inside the network namespace.
  *
  * When enabled alongside netns, the bridge child intercepts DNS
- * queries and emits NetworkBlocked audit events. Requires the
- * serde feature and the wrapper binary with filesystem paths.
+ * queries and emits `NetworkBlocked` audit events. Requires the
+ * `serde` feature and the wrapper binary with filesystem paths.
  *
  * # Safety
  * `profile` must be a valid pointer.
@@ -417,6 +446,19 @@ struct arapuca_ArapucaProcess *arapuca_launch(struct arapuca_ArapucaSandbox *sb,
  * `proc` must be a valid pointer.
  */
 uint32_t arapuca_process_pid(const struct arapuca_ArapucaProcess *proc);
+
+/**
+ * Send a signal to a sandboxed process.
+ *
+ * On Linux 5.3+, uses pidfd_send_signal for race-free delivery.
+ * Falls back to kill() on older kernels or non-Linux platforms.
+ *
+ * Returns 0 on success, -1 on error (check `arapuca_last_error()`).
+ *
+ * # Safety
+ * `proc` must be a valid pointer.
+ */
+int32_t arapuca_process_signal(const struct arapuca_ArapucaProcess *proc, int32_t signal);
 
 /**
  * Wait for a sandboxed process to exit.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -234,6 +234,49 @@ pub unsafe extern "C" fn arapuca_profile_set_netns(profile: *mut ArapucaProfile,
     }
 }
 
+/// Set the seccomp profile for the sandboxed process.
+///
+/// `profile_str` must be a null-terminated string: `"strict"` (default)
+/// or `"baseline"`. Strict blocks AF_INET/AF_INET6, memfd_create,
+/// io_uring, and other advanced syscalls. Baseline blocks only
+/// sandbox-escape syscalls and is designed for trusted-but-isolated
+/// applications such as Claude Code that need full POSIX syscall
+/// access. Returns 0 on success, -1 if the profile string is invalid.
+///
+/// # Safety
+/// `profile` and `profile_str` must be valid pointers.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_seccomp(
+    profile: *mut ArapucaProfile,
+    profile_str: *const c_char,
+) -> i32 {
+    clear_error();
+    let Some(profile) = (unsafe { profile.as_mut() }) else {
+        set_error("null profile pointer");
+        return -1;
+    };
+    let Some(inner) = profile.inner.as_mut() else {
+        set_error("profile already freed");
+        return -1;
+    };
+    let s = match unsafe { validate_cstr(profile_str) } {
+        Ok(s) => s,
+        Err(msg) => {
+            set_error(&msg);
+            return -1;
+        }
+    };
+    match s.as_str() {
+        "strict" => inner.seccomp_profile = crate::SeccompProfile::Strict,
+        "baseline" => inner.seccomp_profile = crate::SeccompProfile::Baseline,
+        _ => {
+            set_error("invalid seccomp profile: expected \"strict\" or \"baseline\"");
+            return -1;
+        }
+    }
+    0
+}
+
 /// Enable or disable PID namespace isolation.
 ///
 /// When enabled, the sandboxed process runs in an isolated PID


### PR DESCRIPTION
Adds `arapuca_profile_set_seccomp()` to the C FFI, allowing library callers to opt in to the Baseline seccomp profile.

## Problem

Claude Code (Bun runtime) is killed with SIGSYS when run through go-arapuca because the library always uses the Strict seccomp profile. The CLI already supports `--seccomp baseline`, and the Baseline profile docstring explicitly names Claude Code as a target use case, but the C FFI has no setter for the profile field.

Without this function, go-arapuca callers cannot select Baseline — forcing them to either ship without seccomp or patch the library.

## Change

Adds `arapuca_profile_set_seccomp(profile, "strict"|"baseline")` to `src/ffi.rs` and the matching declaration to `include/arapuca.h`. Returns 0 on success, -1 on invalid input.

## Verification

- `cargo build` passes
- `cargo test --lib` passes (400 tests)
- Integration test failures in `tests/bridge.rs` are pre-existing on upstream main (unrelated `fork_bridge` arity mismatch)

Relates to #23