### PR TITLE
feat: extend install/uninstall to include binaries and man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 FEATURES ?=
 PREFIX  ?= /usr/local
+BINDIR  ?= $(PREFIX)/bin
 LIBDIR  ?= $(PREFIX)/lib
+MANDIR  ?= $(PREFIX)/share/man
 DESTDIR ?=
 VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 
@@ -116,26 +118,36 @@ package: header
 	test -s target/native-static-libs.txt || \
 	    { echo "ERROR: failed to capture native-static-libs"; exit 1; }
 
-# Install pre-built artifacts. Run 'make package' first (as non-root).
+# Install pre-built artifacts.  Installs whatever was produced by
+# 'make release' and/or 'make package'; skips anything not found.
 install:
-	@test -f target/release/libarapuca.a || \
-	    { echo "ERROR: target/release/libarapuca.a not found — run 'make package' first"; exit 1; }
-	@test -f include/arapuca.h || \
-	    { echo "ERROR: include/arapuca.h not found — run 'make header' first"; exit 1; }
-	@test -s target/native-static-libs.txt || \
-	    { echo "ERROR: target/native-static-libs.txt not found — run 'make package' first"; exit 1; }
-	install -d $(DESTDIR)$(LIBDIR)/pkgconfig
-	install -d $(DESTDIR)$(PREFIX)/include
-	install -m 644 target/release/libarapuca.a $(DESTDIR)$(LIBDIR)/
-	install -m 644 include/arapuca.h $(DESTDIR)$(PREFIX)/include/
-	sed -e 's|@PREFIX@|$(PREFIX)|g' \
-	    -e 's|@LIBDIR@|$(LIBDIR)|g' \
-	    -e 's|@VERSION@|$(VERSION)|g' \
-	    -e "s|@NATIVE_LIBS@|$$(cat target/native-static-libs.txt)|g" \
-	    -e 's|@INSTALL_FEATURES@|$(INSTALL_FEATURES)|g' \
-	    arapuca.pc.in > $(DESTDIR)$(LIBDIR)/pkgconfig/arapuca.pc
+	@for bin in arapuca arapuca-agent; do \
+		test ! -f target/release/$$bin || \
+		    { install -d $(DESTDIR)$(BINDIR) && \
+		      install -m 755 target/release/$$bin $(DESTDIR)$(BINDIR)/; }; \
+	done
+	@test ! -f target/release/libarapuca.a || \
+	    { install -d $(DESTDIR)$(LIBDIR) && \
+	      install -m 644 target/release/libarapuca.a $(DESTDIR)$(LIBDIR)/; }
+	@test ! -f include/arapuca.h || \
+	    { install -d $(DESTDIR)$(PREFIX)/include && \
+	      install -m 644 include/arapuca.h $(DESTDIR)$(PREFIX)/include/; }
+	@test ! -f target/release/libarapuca.a || test ! -s target/native-static-libs.txt || \
+	    { install -d $(DESTDIR)$(LIBDIR)/pkgconfig && \
+	      sed -e 's|@PREFIX@|$(PREFIX)|g' \
+	          -e 's|@LIBDIR@|$(LIBDIR)|g' \
+	          -e 's|@VERSION@|$(VERSION)|g' \
+	          -e "s|@NATIVE_LIBS@|$$(cat target/native-static-libs.txt)|g" \
+	          -e 's|@INSTALL_FEATURES@|$(INSTALL_FEATURES)|g' \
+	          arapuca.pc.in > $(DESTDIR)$(LIBDIR)/pkgconfig/arapuca.pc; }
+	@test ! -f doc/arapuca.1 || \
+	    { install -d $(DESTDIR)$(MANDIR)/man1 && \
+	      install -m 644 doc/arapuca.1 $(DESTDIR)$(MANDIR)/man1/; }
 
 uninstall:
+	rm -f $(DESTDIR)$(BINDIR)/arapuca
+	rm -f $(DESTDIR)$(BINDIR)/arapuca-agent
 	rm -f $(DESTDIR)$(LIBDIR)/libarapuca.a
 	rm -f $(DESTDIR)$(PREFIX)/include/arapuca.h
 	rm -f $(DESTDIR)$(LIBDIR)/pkgconfig/arapuca.pc
+	rm -f $(DESTDIR)$(MANDIR)/man1/arapuca.1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release build-microvm release-microvm agent agent-release test test-unit test-integration lint fmt fmt-check clippy check ci ci-full audit header man clean static package install uninstall
+.PHONY: all build release build-microvm release-microvm agent agent-release test test-unit test-integration lint fmt fmt-check clippy check ci ci-full audit header man clean static package install uninstall
 
 FEATURES ?=
 PREFIX  ?= /usr/local
@@ -7,6 +7,8 @@ LIBDIR  ?= $(PREFIX)/lib
 MANDIR  ?= $(PREFIX)/share/man
 DESTDIR ?=
 VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+
+all: release package man
 
 build:
 	cargo build $(if $(FEATURES),--features $(FEATURES))

--- a/README.md
+++ b/README.md
@@ -717,18 +717,46 @@ cargo +nightly fuzz list
 cargo +nightly fuzz run sanitize_task_id fuzz/seeds/sanitize_task_id
 ```
 
+### Installing
+
+```bash
+# Build everything (release binaries, C library, man page) and install
+make all
+sudo make install
+
+# Or install just the release binaries
+make release
+sudo make install
+
+# Custom prefix (default is /usr/local)
+make release
+sudo make install PREFIX=/opt/arapuca
+
+# Uninstall
+sudo make uninstall
+```
+
+The `install` target installs whatever release artifacts were produced:
+binaries to `$(PREFIX)/bin`, libraries to `$(PREFIX)/lib`, headers to
+`$(PREFIX)/include`, and the man page to `$(PREFIX)/share/man/man1`.
+Artifacts not found are silently skipped.
+
 ### Requirements
 
-- Rust 1.85+ (edition 2024)
-- **Linux**: kernel 5.13+ (Landlock) — degrades gracefully on older
-  kernels; cgroups v2 with delegated controllers (for resource limits)
-- **Linux (microvm feature)**: libkrun + libkrunfw, qemu-img,
-  qemu-nbd (for image probing), OpenSSL development headers, and
-  optionally passt (for VM networking). KVM (`/dev/kvm`) required.
-- **macOS**: `sandbox-exec` (ships with macOS, deprecated but functional
-  through macOS 15)
-- **Windows**: Windows 10+ (64-bit only) — AppContainers require
-  user-mode profile creation (no admin required)
+- Rust 1.85+ (edition 2024) with `cargo`, `rustfmt`,
+  `clippy`
+- `gcc`, `make`, `cbindgen`, `pandoc`
+- **Linux**: kernel 5.13+ (Landlock) — degrades gracefully
+  on older kernels; cgroups v2 with delegated controllers
+  (for resource limits)
+- **Linux (microvm feature)**: libkrun + libkrunfw,
+  qemu-img, qemu-nbd (for image probing), OpenSSL
+  development headers, and optionally passt (for VM
+  networking). KVM (`/dev/kvm`) required
+- **macOS**: `sandbox-exec` (ships with macOS, deprecated
+  but functional through macOS 15)
+- **Windows**: Windows 10+ (64-bit only) — AppContainers
+  require user-mode profile creation (no admin required)
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

- Extend `make install` to install whatever release
  artifacts were built (binaries, library, header,
  pkg-config, man page), skipping anything not found
- Add `make all` target (`release` + `package` + `man`)
  for building all installable artifacts in one step
- Document installation workflow in README under a new
  "Installing" subsection
- Update Requirements to list `rustfmt`, `clippy`,
  `cbindgen`, and `pandoc` as build dependencies

## Related Issues

None

## Test Plan

- [x] `make -n install DESTDIR=/tmp/test` shows correct
  paths for all artifacts
- [x] `make install DESTDIR=/tmp/test` installs binaries,
  library, header, pkg-config, and man page
- [x] `make uninstall DESTDIR=/tmp/test` removes all
  installed files
- [x] `make install` with no prior build completes
  without errors (skips everything)
- [x] `make check` passes (400 tests, 0 failures)

## AI Disclosure

AI-assisted with OpenCode (Claude)