### PR TITLE
fix(darwin): allow traversal of /tmp symlink entry

### DIFF
--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -103,10 +103,11 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
     // explicit access to parent directories for realpath() resolution.
     // /private and /private/var are needed because /var, /etc, and /tmp
     // are symlinks into /private on macOS.
-    // /etc is a symlink to /private/etc — it must be readable for
-    // processes that open /etc/hosts, /etc/resolv.conf, etc.
+    // /etc and /tmp are symlinks (/private/etc, /private/tmp) — their entries
+    // must be resolvable so processes that hardcode /etc/hosts or /tmp/<x>
+    // (e.g. tools that build a runtime dir under /tmp) can traverse the link.
     writeln!(profile, "; Ancestor directories for path traversal").unwrap();
-    for ancestor in &["/opt", "/etc", "/Users", "/private", "/private/var"] {
+    for ancestor in &["/opt", "/etc", "/tmp", "/Users", "/private", "/private/var"] {
         writeln!(profile, "(allow file-read* (literal \"{ancestor}\"))").unwrap();
     }
     writeln!(profile).unwrap();
@@ -479,6 +480,9 @@ mod tests {
         // Verify ancestor directories for path traversal.
         assert!(content.contains("(allow file-read* (literal \"/opt\"))"));
         assert!(content.contains("(allow file-read* (literal \"/etc\"))"));
+        // /tmp is a symlink to /private/tmp; its entry must be resolvable so
+        // tools that hardcode a /tmp/<x> runtime dir can traverse the link.
+        assert!(content.contains("(allow file-read* (literal \"/tmp\"))"));
         assert!(content.contains("(allow file-read* (literal \"/private\"))"));
         assert!(content.contains("(allow file-read* (literal \"/Users\"))"));
         assert!(content.contains("(allow file-read* (literal \"/private/var\"))"));


### PR DESCRIPTION
The ancestor traversal list allows `/etc` (a symlink to `/private/etc`) but not `/tmp` (a symlink to `/private/tmp`).

On macOS, a process that opens a hardcoded `/tmp/<x>` path — for example a tool that builds its runtime dir under `/tmp/<name>-<uid>` — needs to read the `/tmp` link entry to resolve the real path. Without it, `realpath()` hits EPERM even when the canonical `/private/tmp` location is mounted.

Add `/tmp` alongside `/etc` in the traversable ancestor entries, and cover it in the profile test.