### PR TITLE
feat(darwin): add --allow-proxy-env to forward proxy vars into the sandbox

### DIFF
--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -590,6 +590,7 @@ fn run_subcommand(args: &[String]) {
     #[allow(unused_mut, unused_variables)]
     let mut seccomp_debug = false;
     let mut audit_network = false;
+    let mut allow_proxy_env = false;
 
     // Find -- separator.
     let sep_pos = args.iter().position(|a| a == "--");
@@ -618,6 +619,9 @@ fn run_subcommand(args: &[String]) {
             eprintln!("  --audit-files      emit file access and process spawn audit events");
             eprintln!("  --seccomp-debug    log blocked syscalls to stderr instead of killing");
             eprintln!("  --audit-network    emit network connection audit events");
+            eprintln!(
+                "  --allow-proxy-env  forward HTTP(S)_PROXY/NO_PROXY from the caller's env"
+            );
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  --no-pid-ns        disable PID namespace isolation");
             eprintln!("  -t, --tty          allocate a PTY for interactive programs");
@@ -810,6 +814,9 @@ fn run_subcommand(args: &[String]) {
             "--audit-files" => {
                 audit_files = true;
             }
+            "--allow-proxy-env" => {
+                allow_proxy_env = true;
+            }
             "--audit-network" => {
                 audit_network = true;
             }
@@ -933,6 +940,7 @@ fn run_subcommand(args: &[String]) {
         audit_file_access: audit_files,
         audit_network: audit_network || deny_network,
         seccomp_debug,
+        allow_proxy_env,
         ..Default::default()
     };
 

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -421,6 +421,29 @@ impl Sandbox for Darwin {
         let filter_result = crate::env::filter_caller_env(&cfg.env);
         env_vars.extend(filter_result.passed);
 
+        // Forward HTTP(S) proxy vars from the launcher's own (trusted)
+        // environment, bypassing the caller-env filter. Opt-in via
+        // --allow-proxy-env for tools that must reach the network
+        // through a local proxy in baseline network mode.
+        if cfg.profile.allow_proxy_env {
+            for key in &[
+                "HTTP_PROXY",
+                "http_proxy",
+                "HTTPS_PROXY",
+                "https_proxy",
+                "ALL_PROXY",
+                "all_proxy",
+                "NO_PROXY",
+                "no_proxy",
+            ] {
+                if let Ok(val) = std::env::var(key) {
+                    if !val.is_empty() {
+                        env_vars.push(((*key).to_string(), val));
+                    }
+                }
+            }
+        }
+
         if let Some(ref ctx) = audit_ctx {
             ctx.emit(AuditEvent::EnvPolicy {
                 timestamp: ctx.timestamp(),

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -168,6 +168,20 @@ pub struct Profile {
     /// blocked syscall names to stderr. Does NOT affect the main
     /// sandbox filter protecting the untrusted process.
     pub seccomp_debug: bool,
+    /// Forward standard HTTP(S) proxy environment variables from the
+    /// launching process to the sandboxed process.
+    ///
+    /// The caller-env filter normally strips `HTTP_PROXY`/`HTTPS_PROXY`/
+    /// `NO_PROXY` (and lowercase/`ALL_PROXY` variants) because an
+    /// attacker-influenced proxy could redirect or MITM the sandboxed
+    /// process's traffic. When true, the launcher instead injects those
+    /// variables from its OWN environment (a trusted operator source),
+    /// bypassing the filter, so tools that must reach the network
+    /// through a local proxy work in baseline network mode.
+    ///
+    /// Only meaningful when outbound network is allowed (macOS baseline
+    /// seccomp mode). Ignored on other platforms.
+    pub allow_proxy_env: bool,
 }
 
 /// Full configuration for launching a sandboxed process.


### PR DESCRIPTION
## What

Adds an opt-in `--allow-proxy-env` flag (and `Profile::allow_proxy_env`) that forwards the standard HTTP(S) proxy environment variables into the sandboxed process on macOS.

## Why

`filter_caller_env` deliberately strips `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (and the lowercase/`ALL_PROXY` variants) so an attacker-influenced proxy can't redirect or MITM an **untrusted** sandboxed process. That same stripping also blocks the legitimate operator case: running a **trusted** tool that must reach the network through a local proxy (corporate proxy, or when direct egress to an API is blocked and only a local proxy works).

## How

When `--allow-proxy-env` is set, the macOS launcher injects the standard proxy variables from its **own** (trusted operator) environment, appended **after** and bypassing the caller-env filter. Only meaningful in baseline network mode; ignored on other platforms and when unset.

- `src/profile.rs` — new `allow_proxy_env` field
- `src/platform/darwin/mod.rs` — inject proxy vars from the launcher env after filtering
- `src/bin/arapuca.rs` — `--allow-proxy-env` flag + help

## Testing

`cargo test` (218 passed) and `cargo clippy` clean. Verified in baseline mode that a sandboxed `curl`/tool reaches an API through a local proxy that direct egress cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)