### PR TITLE
feat(darwin): add --allow-keychain for native macOS Keychain access

### DIFF
--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -590,6 +590,7 @@ fn run_subcommand(args: &[String]) {
     #[allow(unused_mut, unused_variables)]
     let mut seccomp_debug = false;
     let mut audit_network = false;
+    let mut allow_keychain = false;
 
     // Find -- separator.
     let sep_pos = args.iter().position(|a| a == "--");
@@ -620,6 +621,10 @@ fn run_subcommand(args: &[String]) {
             eprintln!("  --audit-network    emit network connection audit events");
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  --no-pid-ns        disable PID namespace isolation");
+            eprintln!(
+                "  --allow-keychain   allow macOS Keychain access; sets HOME to your \
+                 home dir (macOS only)"
+            );
             eprintln!("  -t, --tty          allocate a PTY for interactive programs");
             if sep_pos.is_none() && !args.is_empty() {
                 eprintln!();
@@ -810,6 +815,14 @@ fn run_subcommand(args: &[String]) {
             "--audit-files" => {
                 audit_files = true;
             }
+            "--allow-keychain" => {
+                allow_keychain = true;
+                #[cfg(not(target_os = "macos"))]
+                eprintln!(
+                    "arapuca run: --allow-keychain has no effect on this platform \
+                     (macOS Keychain only)"
+                );
+            }
             "--audit-network" => {
                 audit_network = true;
             }
@@ -933,6 +946,7 @@ fn run_subcommand(args: &[String]) {
         audit_file_access: audit_files,
         audit_network: audit_network || deny_network,
         seccomp_debug,
+        allow_keychain,
         ..Default::default()
     };
 

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -31,6 +31,15 @@ pub struct ProfileData {
     /// IPC services needed for DNS and TLS on macOS. There is no
     /// per-host filtering (unlike Linux's netns + CONNECT proxy).
     pub allow_network: bool,
+    /// Allow access to the macOS Keychain.
+    ///
+    /// When true, the profile grants the `securityd`/`trustd` Mach
+    /// lookups and read access to the Keychain database files so
+    /// `Security.framework` can read Keychain items (e.g. an app's
+    /// stored OAuth token). Without this, a deny-default profile makes
+    /// Keychain reads fail silently and Keychain-backed authentication
+    /// reports "not logged in".
+    pub allow_keychain: bool,
 }
 
 /// Validate that a path contains only safe characters for embedding in
@@ -434,6 +443,35 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
     }
     writeln!(profile).unwrap();
 
+    // Keychain access (opt-in via --allow-keychain).
+    //
+    // Reading a Keychain item goes through securityd over Mach IPC;
+    // trustd/ocspd back certificate trust evaluation. The file-based
+    // login keychain is also read directly by Security.framework, so
+    // grant read access to the system Keychain directory and the
+    // metadata store. The user's login keychain directory
+    // (~/Library/Keychains) is added to read_paths by the launcher.
+    if data.allow_keychain {
+        writeln!(profile, "; Keychain (--allow-keychain)").unwrap();
+        for service in &[
+            "com.apple.SecurityServer",
+            "com.apple.trustd",
+            "com.apple.trustd.agent",
+            "com.apple.ocspd",
+            "com.apple.CoreServices.coreservicesd",
+        ] {
+            writeln!(profile, "(allow mach-lookup (global-name \"{service}\"))").unwrap();
+        }
+        for path in &[
+            "/Library/Keychains",
+            "/System/Library/Keychains",
+            "/private/var/db/mds",
+        ] {
+            writeln!(profile, "(allow file-read* (subpath \"{path}\"))").unwrap();
+        }
+        writeln!(profile).unwrap();
+    }
+
     // POSIX shared memory (read-only).
     writeln!(profile, "; POSIX shm").unwrap();
     writeln!(profile, "(allow ipc-posix-shm-read-data)").unwrap();
@@ -525,6 +563,7 @@ mod tests {
             control_socket: Some("/tmp/sock/control.sock".into()),
             llm_socket: Some("/tmp/sock/llm.sock".into()),
             allow_network: false,
+            allow_keychain: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();
@@ -633,6 +672,7 @@ mod tests {
             control_socket: None,
             llm_socket: None,
             allow_network: false,
+            allow_keychain: false,
         };
         let path = generate_profile(&dir, &data).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
@@ -665,6 +705,7 @@ mod tests {
             control_socket: None,
             llm_socket: None,
             allow_network: false,
+            allow_keychain: false,
         };
 
         let result = generate_profile(&dir, &data);
@@ -686,6 +727,7 @@ mod tests {
             control_socket: None,
             llm_socket: None,
             allow_network: true,
+            allow_keychain: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();
@@ -744,6 +786,45 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_profile_keychain() {
+        let dir_off = std::env::temp_dir().join("arapuca-test-profile-keychain-off");
+        let dir_on = std::env::temp_dir().join("arapuca-test-profile-keychain-on");
+        let _ = std::fs::create_dir_all(&dir_off);
+        let _ = std::fs::create_dir_all(&dir_on);
+
+        // Keychain disabled: no securityd Mach lookup, no keychain files.
+        let off = ProfileData {
+            read_paths: vec!["/home/user/src".into()],
+            write_paths: vec![],
+            exec_paths: vec![],
+            control_socket: None,
+            llm_socket: None,
+            allow_network: false,
+            allow_keychain: false,
+        };
+        let content_off =
+            std::fs::read_to_string(generate_profile(&dir_off, &off).unwrap()).unwrap();
+        assert!(!content_off.contains("com.apple.SecurityServer"));
+        assert!(!content_off.contains("(allow file-read* (subpath \"/Library/Keychains\"))"));
+
+        // Keychain enabled: securityd/ocspd Mach lookups + keychain files.
+        let on = ProfileData {
+            allow_keychain: true,
+            ..off
+        };
+        let content_on = std::fs::read_to_string(generate_profile(&dir_on, &on).unwrap()).unwrap();
+        assert!(content_on.contains("(allow mach-lookup (global-name \"com.apple.SecurityServer\"))"));
+        assert!(content_on.contains("com.apple.ocspd"));
+        assert!(content_on.contains("(allow file-read* (subpath \"/Library/Keychains\"))"));
+        assert!(content_on.contains("(allow file-read* (subpath \"/private/var/db/mds\"))"));
+        // deny-default is preserved.
+        assert!(content_on.contains("(deny default)"));
+
+        let _ = std::fs::remove_dir_all(&dir_off);
+        let _ = std::fs::remove_dir_all(&dir_on);
+    }
+
+    #[test]
     fn test_generate_profile_proxy_only() {
         let dir = std::env::temp_dir().join("arapuca-test-profile-proxy");
         let _ = std::fs::create_dir_all(&dir);
@@ -755,6 +836,7 @@ mod tests {
             control_socket: None,
             llm_socket: Some("/tmp/sock/proxy.sock".into()),
             allow_network: false,
+            allow_keychain: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -300,6 +300,19 @@ impl Sandbox for Darwin {
             }
         }
 
+        // When Keychain access is requested, add the user's login
+        // Keychain directory to read paths. The file-based login
+        // keychain is read directly by Security.framework; the
+        // securityd/trustd Mach services are granted by the profile.
+        if cfg.profile.allow_keychain {
+            if let Some(home) = std::env::var_os("HOME") {
+                let kc = std::path::Path::new(&home).join("Library/Keychains");
+                if kc.exists() {
+                    read_paths.push(canon(&kc));
+                }
+            }
+        }
+
         // Canonicalize cmd early so exec_paths and actual_cmd use
         // the same resolved path. Seatbelt does NOT resolve symlinks
         // in the target binary path for process-exec checks.
@@ -341,6 +354,7 @@ impl Sandbox for Darwin {
             control_socket,
             llm_socket,
             allow_network,
+            allow_keychain: cfg.profile.allow_keychain,
         };
 
         // Generate the Seatbelt profile.
@@ -393,6 +407,24 @@ impl Sandbox for Darwin {
                 entry.1 = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:\
                             /usr/local/sbin:/usr/sbin:/sbin"
                     .into();
+            }
+        }
+
+        // When Keychain access is enabled, point HOME at the caller's real
+        // home directory instead of the sandbox temp dir. The macOS
+        // Keychain search list is derived from HOME; with the default temp
+        // HOME the login keychain is absent from the search list and
+        // Keychain items cannot be found (reads fail as "item not found").
+        // Confinement is unaffected: access is bounded by the mount profile,
+        // not by $HOME, so an un-mounted home still yields EPERM.
+        if cfg.profile.allow_keychain {
+            if let Some(home) = std::env::var_os("HOME") {
+                let home = home.to_string_lossy().into_owned();
+                if let Some(entry) = env_vars.iter_mut().find(|(k, _)| k == "HOME") {
+                    entry.1 = home;
+                } else {
+                    env_vars.push(("HOME".into(), home));
+                }
             }
         }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -168,6 +168,28 @@ pub struct Profile {
     /// blocked syscall names to stderr. Does NOT affect the main
     /// sandbox filter protecting the untrusted process.
     pub seccomp_debug: bool,
+    /// Grant the sandboxed process access to the macOS Keychain
+    /// (macOS only; ignored on other platforms).
+    ///
+    /// The deny-default Seatbelt profile blocks the Mach services and
+    /// files that `Security.framework` needs to read Keychain items,
+    /// so tools that authenticate via the login Keychain (e.g. Claude
+    /// Code's subscription OAuth token stored under
+    /// `Claude Code-credentials`) report "not logged in" inside the
+    /// sandbox. When true, the profile additionally allows the
+    /// `securityd`/`trustd` Mach lookups and read access to the
+    /// Keychain database files so native Keychain authentication works.
+    ///
+    /// On macOS this also points `HOME` at the launching user's real home
+    /// directory (the Keychain search list is derived from `HOME`; the
+    /// sandbox's default temp `HOME` omits the login keychain, so items
+    /// cannot be found otherwise). Confinement is unaffected — the mount
+    /// profile, not `$HOME`, bounds what is accessible.
+    ///
+    /// This widens the sandbox: the process can read any Keychain item
+    /// the invoking user can. Enable only for trusted tools that need
+    /// Keychain-backed credentials.
+    pub allow_keychain: bool,
 }
 
 /// Full configuration for launching a sandboxed process.


### PR DESCRIPTION
## What

Adds an opt-in `--allow-keychain` flag (and `Profile::allow_keychain`) that lets a trusted sandboxed tool authenticate natively against the macOS login Keychain — no need to export credentials to a file.

## Why

A `(deny default)` Seatbelt profile blocks the Mach services and files that `Security.framework` needs to read Keychain items. Tools that authenticate via the login Keychain (e.g. Claude Code's subscription OAuth token stored under `Claude Code-credentials`) therefore report **"not logged in"** inside the sandbox.

## How

On macOS, `--allow-keychain`:

- grants the `securityd`/`trustd`/`ocspd` Mach lookups and read access to the Keychain database files (`/Library/Keychains`, `/System/Library/Keychains`, `/private/var/db/mds`) in the generated profile;
- adds the user's login keychain directory (`~/Library/Keychains`) to the read mounts;
- points `HOME` at the launching user's **real** home directory. The macOS Keychain search list is derived from `HOME`; with the sandbox's default temp `HOME` the login keychain is absent from the search list and items cannot be found ("item not found"). **Confinement is unaffected** — the mount profile, not `$HOME`, bounds what is accessible, so an un-mounted home still yields `EPERM`.

Ignored on non-macOS platforms.

## Security note

This widens the sandbox: the process can read any Keychain item the invoking user can. It is opt-in and intended only for trusted tools that need Keychain-backed credentials — consistent with the existing `--allow-host` style of explicit operator opt-in.

## Testing

`cargo test` (219 passed, incl. a new `test_generate_profile_keychain` asserting the profile grants/omits the Keychain rules by flag) and `cargo clippy` clean.

Verified end-to-end with Claude Code on macOS: without the flag `claude -p` reports "not logged in"; with `--allow-keychain` subscription auth succeeds and the request reaches the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)