### PR TITLE
darwin: add --allow-proxy-env to forward proxy vars into the sandbox

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -75,10 +75,22 @@ pub enum AuditEvent {
     ///
     /// Key names are logged (the audit consumer already has full visibility
     /// into the environment). Values are NEVER logged.
+    ///
+    /// `passed_keys` is the full set of keys the sandboxed process receives
+    /// (base env, caller-supplied keys that survived filtering, and any
+    /// launcher-injected keys). `injected_keys` annotates the subset of
+    /// those keys that the trusted launcher injected on its own, bypassing
+    /// the caller-env filter (e.g. proxy vars under `--allow-proxy-env`);
+    /// each carries the [`InjectReason`] explaining why. `dropped` records
+    /// caller keys the filter rejected and is independent of the other two:
+    /// a key an untrusted caller tried to set can appear in `dropped` (their
+    /// value was refused) while the same key appears in `injected_keys` (the
+    /// launcher supplied its own trusted value).
     #[non_exhaustive]
     EnvPolicy {
         timestamp: AuditTimestamp,
         passed_keys: Vec<String>,
+        injected_keys: Vec<InjectedEnvVar>,
         dropped: Vec<DroppedEnvVar>,
     },
 
@@ -343,6 +355,27 @@ pub enum DropReason {
 pub struct DroppedEnvVar {
     pub key: String,
     pub reason: DropReason,
+}
+
+/// Why the trusted launcher injected an environment variable, bypassing
+/// the caller-env filter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub enum InjectReason {
+    /// Proxy vars forwarded from the launcher's own environment under
+    /// `--allow-proxy-env` (only when outbound network is allowed).
+    ProxyEnv,
+}
+
+/// An environment variable the launcher injected on its own, bypassing
+/// the caller-env filter. Its value comes from the trusted launcher
+/// environment, not from the (untrusted) caller.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct InjectedEnvVar {
+    pub key: String,
+    pub reason: InjectReason,
 }
 
 /// Controls how much detail audit events include.

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -590,6 +590,7 @@ fn run_subcommand(args: &[String]) {
     #[allow(unused_mut, unused_variables)]
     let mut seccomp_debug = false;
     let mut audit_network = false;
+    let mut allow_proxy_env = false;
 
     // Find -- separator.
     let sep_pos = args.iter().position(|a| a == "--");
@@ -618,6 +619,7 @@ fn run_subcommand(args: &[String]) {
             eprintln!("  --audit-files      emit file access and process spawn audit events");
             eprintln!("  --seccomp-debug    log blocked syscalls to stderr instead of killing");
             eprintln!("  --audit-network    emit network connection audit events");
+            eprintln!("  --allow-proxy-env  forward HTTP(S)_PROXY/NO_PROXY from the caller's env");
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  --no-pid-ns        disable PID namespace isolation");
             eprintln!("  -t, --tty          allocate a PTY for interactive programs");
@@ -810,6 +812,9 @@ fn run_subcommand(args: &[String]) {
             "--audit-files" => {
                 audit_files = true;
             }
+            "--allow-proxy-env" => {
+                allow_proxy_env = true;
+            }
             "--audit-network" => {
                 audit_network = true;
             }
@@ -933,6 +938,7 @@ fn run_subcommand(args: &[String]) {
         audit_file_access: audit_files,
         audit_network: audit_network || deny_network,
         seccomp_debug,
+        allow_proxy_env,
         ..Default::default()
     };
 

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -619,7 +619,11 @@ fn run_subcommand(args: &[String]) {
             eprintln!("  --audit-files      emit file access and process spawn audit events");
             eprintln!("  --seccomp-debug    log blocked syscalls to stderr instead of killing");
             eprintln!("  --audit-network    emit network connection audit events");
-            eprintln!("  --allow-proxy-env  forward HTTP(S)_PROXY/NO_PROXY from the caller's env");
+            eprintln!(
+                "  --allow-proxy-env  forward HTTP(S)_PROXY/ALL_PROXY/NO_PROXY from the caller's env"
+            );
+            eprintln!("                     (proxy routing only; TLS trust-anchor vars such as");
+            eprintln!("                     SSL_CERT_FILE/CURL_CA_BUNDLE are not forwarded)");
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  --no-pid-ns        disable PID namespace isolation");
             eprintln!("  -t, --tty          allocate a PTY for interactive programs");
@@ -814,6 +818,11 @@ fn run_subcommand(args: &[String]) {
             }
             "--allow-proxy-env" => {
                 allow_proxy_env = true;
+                #[cfg(not(target_os = "macos"))]
+                eprintln!(
+                    "arapuca run: --allow-proxy-env is macOS-only; \
+                     ignored on this platform"
+                );
             }
             "--audit-network" => {
                 audit_network = true;

--- a/src/env.rs
+++ b/src/env.rs
@@ -722,6 +722,33 @@ mod tests {
         assert_eq!(result.dropped[0].reason, DropReason::DyldPrefix);
     }
 
+    /// Contract test: every proxy var forwarded by `--allow-proxy-env`
+    /// (see the darwin launcher) must be dropped by `filter_caller_env`,
+    /// so re-injecting from the trusted launcher env is safe and the two
+    /// lists cannot silently drift apart.
+    #[test]
+    fn filter_drops_all_proxy_vars_that_allow_proxy_env_forwards() {
+        let forwarded = [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ];
+        for key in &forwarded {
+            let env = vec![((*key).to_string(), "http://proxy".into())];
+            let result = filter_caller_env(&env);
+            assert!(
+                result.passed.is_empty(),
+                "filter must drop {key} so allow_proxy_env can safely re-inject it"
+            );
+            assert_eq!(result.dropped[0].reason, DropReason::RuntimeInjection);
+        }
+    }
+
     #[test]
     fn filter_drops_interpreter_injection() {
         let blocked = vec![

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -421,6 +421,29 @@ impl Sandbox for Darwin {
         let filter_result = crate::env::filter_caller_env(&cfg.env);
         env_vars.extend(filter_result.passed);
 
+        // Forward HTTP(S) proxy vars from the launcher's own (trusted)
+        // environment, bypassing the caller-env filter. Opt-in via
+        // --allow-proxy-env for tools that must reach the network
+        // through a local proxy in baseline network mode.
+        if cfg.profile.allow_proxy_env {
+            for key in &[
+                "HTTP_PROXY",
+                "http_proxy",
+                "HTTPS_PROXY",
+                "https_proxy",
+                "ALL_PROXY",
+                "all_proxy",
+                "NO_PROXY",
+                "no_proxy",
+            ] {
+                if let Ok(val) = std::env::var(key) {
+                    if !val.is_empty() {
+                        env_vars.push(((*key).to_string(), val));
+                    }
+                }
+            }
+        }
+
         if let Some(ref ctx) = audit_ctx {
             ctx.emit(AuditEvent::EnvPolicy {
                 timestamp: ctx.timestamp(),

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -20,8 +20,8 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 use crate::audit::{
-    AuditContext, AuditEvent, AuditVerbosity, SCHEMA_VERSION, SandboxLayer, SkipReason,
-    sanitize_audit_string,
+    AuditContext, AuditEvent, AuditVerbosity, InjectReason, InjectedEnvVar, SCHEMA_VERSION,
+    SandboxLayer, SkipReason, sanitize_audit_string,
 };
 use crate::platform::Sandbox;
 use crate::{Config, Error, process::Process};
@@ -425,7 +425,17 @@ impl Sandbox for Darwin {
         // environment, bypassing the caller-env filter. Opt-in via
         // --allow-proxy-env for tools that must reach the network
         // through a local proxy in baseline network mode.
-        if cfg.profile.allow_proxy_env {
+        //
+        // Gate on allow_network so proxy vars (which may carry
+        // credentials in the URL) are never injected when outbound
+        // network is blocked by Seatbelt; otherwise the untrusted
+        // process could read and exfiltrate them despite no egress.
+        //
+        // Injected keys are also recorded separately in the EnvPolicy
+        // audit event so an auditor can tell launcher-injected vars apart
+        // from caller-supplied vars that passed the filter.
+        let mut injected_keys = Vec::new();
+        if cfg.profile.allow_proxy_env && allow_network {
             for key in &[
                 "HTTP_PROXY",
                 "http_proxy",
@@ -439,6 +449,10 @@ impl Sandbox for Darwin {
                 if let Ok(val) = std::env::var(key) {
                     if !val.is_empty() {
                         env_vars.push(((*key).to_string(), val));
+                        injected_keys.push(InjectedEnvVar {
+                            key: (*key).to_string(),
+                            reason: InjectReason::ProxyEnv,
+                        });
                     }
                 }
             }
@@ -448,6 +462,7 @@ impl Sandbox for Darwin {
             ctx.emit(AuditEvent::EnvPolicy {
                 timestamp: ctx.timestamp(),
                 passed_keys: env_vars.iter().map(|(k, _)| k.clone()).collect(),
+                injected_keys,
                 dropped: filter_result.dropped,
             })?;
         }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -430,6 +430,7 @@ impl Sandbox for Linux {
             ctx.emit(AuditEvent::EnvPolicy {
                 timestamp: ctx.timestamp(),
                 passed_keys: env_vars.iter().map(|(k, _)| k.clone()).collect(),
+                injected_keys: Vec::new(),
                 dropped: filter_result.dropped,
             })?;
         }

--- a/src/platform/microvm.rs
+++ b/src/platform/microvm.rs
@@ -287,6 +287,7 @@ impl Sandbox for MicroVm {
                     .iter()
                     .map(|(k, _)| k.clone())
                     .collect(),
+                injected_keys: Vec::new(),
                 dropped: filter_result.dropped,
             })?;
         }

--- a/src/platform/other.rs
+++ b/src/platform/other.rs
@@ -120,6 +120,7 @@ impl Sandbox for Other {
             ctx.emit(AuditEvent::EnvPolicy {
                 timestamp: ctx.timestamp(),
                 passed_keys: env_vars.iter().map(|(k, _)| k.clone()).collect(),
+                injected_keys: Vec::new(),
                 dropped: filter_result.dropped,
             })?;
         }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -168,6 +168,20 @@ pub struct Profile {
     /// blocked syscall names to stderr. Does NOT affect the main
     /// sandbox filter protecting the untrusted process.
     pub seccomp_debug: bool,
+    /// Forward standard HTTP(S) proxy environment variables from the
+    /// launching process to the sandboxed process.
+    ///
+    /// The caller-env filter normally strips `HTTP_PROXY`/`HTTPS_PROXY`/
+    /// `NO_PROXY` (and lowercase/`ALL_PROXY` variants) because an
+    /// attacker-influenced proxy could redirect or MITM the sandboxed
+    /// process's traffic. When true, the launcher instead injects those
+    /// variables from its OWN environment (a trusted operator source),
+    /// bypassing the filter, so tools that must reach the network
+    /// through a local proxy work in baseline network mode.
+    ///
+    /// Only meaningful when outbound network is allowed (macOS baseline
+    /// seccomp mode). Ignored on other platforms.
+    pub allow_proxy_env: bool,
 }
 
 /// Full configuration for launching a sandboxed process.

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -320,6 +320,7 @@ fn env_filtering_audited() {
     match env_event.unwrap() {
         AuditEvent::EnvPolicy {
             passed_keys,
+            injected_keys,
             dropped,
             ..
         } => {
@@ -327,6 +328,8 @@ fn env_filtering_audited() {
             assert!(!passed_keys.iter().any(|k| k == "LD_PRELOAD"));
             assert_eq!(dropped.len(), 1);
             assert_eq!(dropped[0].key, "LD_PRELOAD");
+            // Without --allow-proxy-env the launcher injects nothing.
+            assert!(injected_keys.is_empty());
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
Adds an opt-in `--allow-proxy-env` flag.

`filter_caller_env` strips `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` (and the lowercase and `ALL_PROXY` variants) so an untrusted process can't be redirected through an attacker-controlled proxy. That also blocks the legitimate case: a trusted tool that needs a local proxy to reach the network (e.g. when direct egress to an API is blocked).

With `--allow-proxy-env`, the macOS launcher forwards these variables from its own environment, after and bypassing the caller-env filter. Only applies in baseline network mode; ignored otherwise.

Tested: `cargo test` (218) and `cargo clippy` pass.