### PR TITLE
darwin: add --allow-keychain for macOS Keychain access

### DIFF
--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -591,6 +591,7 @@ fn run_subcommand(args: &[String]) {
     let mut seccomp_debug = false;
     let mut audit_network = false;
     let mut allow_proxy_env = false;
+    let mut allow_keychain = false;
 
     // Find -- separator.
     let sep_pos = args.iter().position(|a| a == "--");
@@ -626,6 +627,10 @@ fn run_subcommand(args: &[String]) {
             eprintln!("                     SSL_CERT_FILE/CURL_CA_BUNDLE are not forwarded)");
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  --no-pid-ns        disable PID namespace isolation");
+            eprintln!(
+                "  --allow-keychain   allow macOS Keychain access; sets HOME to your \
+                 home dir (macOS only)"
+            );
             eprintln!("  -t, --tty          allocate a PTY for interactive programs");
             if sep_pos.is_none() && !args.is_empty() {
                 eprintln!();
@@ -824,6 +829,14 @@ fn run_subcommand(args: &[String]) {
                      ignored on this platform"
                 );
             }
+            "--allow-keychain" => {
+                allow_keychain = true;
+                #[cfg(not(target_os = "macos"))]
+                eprintln!(
+                    "arapuca run: --allow-keychain has no effect on this platform \
+                     (macOS Keychain only)"
+                );
+            }
             "--audit-network" => {
                 audit_network = true;
             }
@@ -948,6 +961,7 @@ fn run_subcommand(args: &[String]) {
         audit_network: audit_network || deny_network,
         seccomp_debug,
         allow_proxy_env,
+        allow_keychain,
         ..Default::default()
     };
 

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -31,6 +31,15 @@ pub struct ProfileData {
     /// IPC services needed for DNS and TLS on macOS. There is no
     /// per-host filtering (unlike Linux's netns + CONNECT proxy).
     pub allow_network: bool,
+    /// Allow access to the macOS Keychain.
+    ///
+    /// When true, the profile grants the `securityd`/`trustd` Mach
+    /// lookups and read access to the Keychain database files so
+    /// `Security.framework` can read Keychain items (e.g. an app's
+    /// stored OAuth token). Without this, a deny-default profile makes
+    /// Keychain reads fail silently and Keychain-backed authentication
+    /// reports "not logged in".
+    pub allow_keychain: bool,
 }
 
 /// Validate that a path contains only safe characters for embedding in
@@ -434,6 +443,35 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
     }
     writeln!(profile).unwrap();
 
+    // Keychain access (opt-in via --allow-keychain).
+    //
+    // Reading a Keychain item goes through securityd over Mach IPC;
+    // trustd/ocspd back certificate trust evaluation. The file-based
+    // login keychain is also read directly by Security.framework, so
+    // grant read access to the system Keychain directory and the
+    // metadata store. The user's login keychain directory
+    // (~/Library/Keychains) is added to read_paths by the launcher.
+    if data.allow_keychain {
+        writeln!(profile, "; Keychain (--allow-keychain)").unwrap();
+        for service in &[
+            "com.apple.SecurityServer",
+            "com.apple.trustd",
+            "com.apple.trustd.agent",
+            "com.apple.ocspd",
+            "com.apple.CoreServices.coreservicesd",
+        ] {
+            writeln!(profile, "(allow mach-lookup (global-name \"{service}\"))").unwrap();
+        }
+        for path in &[
+            "/Library/Keychains",
+            "/System/Library/Keychains",
+            "/private/var/db/mds",
+        ] {
+            writeln!(profile, "(allow file-read* (subpath \"{path}\"))").unwrap();
+        }
+        writeln!(profile).unwrap();
+    }
+
     // POSIX shared memory (read-only).
     writeln!(profile, "; POSIX shm").unwrap();
     writeln!(profile, "(allow ipc-posix-shm-read-data)").unwrap();
@@ -525,6 +563,7 @@ mod tests {
             control_socket: Some("/tmp/sock/control.sock".into()),
             llm_socket: Some("/tmp/sock/llm.sock".into()),
             allow_network: false,
+            allow_keychain: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();
@@ -633,6 +672,7 @@ mod tests {
             control_socket: None,
             llm_socket: None,
             allow_network: false,
+            allow_keychain: false,
         };
         let path = generate_profile(&dir, &data).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
@@ -665,6 +705,7 @@ mod tests {
             control_socket: None,
             llm_socket: None,
             allow_network: false,
+            allow_keychain: false,
         };
 
         let result = generate_profile(&dir, &data);
@@ -686,6 +727,7 @@ mod tests {
             control_socket: None,
             llm_socket: None,
             allow_network: true,
+            allow_keychain: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();
@@ -744,6 +786,47 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_profile_keychain() {
+        let dir_off = std::env::temp_dir().join("arapuca-test-profile-keychain-off");
+        let dir_on = std::env::temp_dir().join("arapuca-test-profile-keychain-on");
+        let _ = std::fs::create_dir_all(&dir_off);
+        let _ = std::fs::create_dir_all(&dir_on);
+
+        // Keychain disabled: no securityd Mach lookup, no keychain files.
+        let off = ProfileData {
+            read_paths: vec!["/home/user/src".into()],
+            write_paths: vec![],
+            exec_paths: vec![],
+            control_socket: None,
+            llm_socket: None,
+            allow_network: false,
+            allow_keychain: false,
+        };
+        let content_off =
+            std::fs::read_to_string(generate_profile(&dir_off, &off).unwrap()).unwrap();
+        assert!(!content_off.contains("com.apple.SecurityServer"));
+        assert!(!content_off.contains("(allow file-read* (subpath \"/Library/Keychains\"))"));
+
+        // Keychain enabled: securityd/ocspd Mach lookups + keychain files.
+        let on = ProfileData {
+            allow_keychain: true,
+            ..off
+        };
+        let content_on = std::fs::read_to_string(generate_profile(&dir_on, &on).unwrap()).unwrap();
+        assert!(
+            content_on.contains("(allow mach-lookup (global-name \"com.apple.SecurityServer\"))")
+        );
+        assert!(content_on.contains("com.apple.ocspd"));
+        assert!(content_on.contains("(allow file-read* (subpath \"/Library/Keychains\"))"));
+        assert!(content_on.contains("(allow file-read* (subpath \"/private/var/db/mds\"))"));
+        // deny-default is preserved.
+        assert!(content_on.contains("(deny default)"));
+
+        let _ = std::fs::remove_dir_all(&dir_off);
+        let _ = std::fs::remove_dir_all(&dir_on);
+    }
+
+    #[test]
     fn test_generate_profile_proxy_only() {
         let dir = std::env::temp_dir().join("arapuca-test-profile-proxy");
         let _ = std::fs::create_dir_all(&dir);
@@ -755,6 +838,7 @@ mod tests {
             control_socket: None,
             llm_socket: Some("/tmp/sock/proxy.sock".into()),
             allow_network: false,
+            allow_keychain: false,
         };
 
         let path = generate_profile(&dir, &data).unwrap();

--- a/src/platform/darwin/darwin_profile.rs
+++ b/src/platform/darwin/darwin_profile.rs
@@ -453,13 +453,15 @@ pub fn generate_profile(dir: &Path, data: &ProfileData) -> crate::Result<std::pa
     // (~/Library/Keychains) is added to read_paths by the launcher.
     if data.allow_keychain {
         writeln!(profile, "; Keychain (--allow-keychain)").unwrap();
-        for service in &[
-            "com.apple.SecurityServer",
-            "com.apple.trustd",
-            "com.apple.trustd.agent",
-            "com.apple.ocspd",
-            "com.apple.CoreServices.coreservicesd",
-        ] {
+        let mut services = vec!["com.apple.SecurityServer", "com.apple.ocspd"];
+        // trustd/trustd.agent back certificate trust evaluation. When
+        // networking is enabled they are already granted in the network
+        // block above, so only emit them here to avoid a duplicate.
+        if !data.allow_network {
+            services.push("com.apple.trustd");
+            services.push("com.apple.trustd.agent");
+        }
+        for service in &services {
             writeln!(profile, "(allow mach-lookup (global-name \"{service}\"))").unwrap();
         }
         for path in &[
@@ -821,9 +823,38 @@ mod tests {
         assert!(content_on.contains("(allow file-read* (subpath \"/private/var/db/mds\"))"));
         // deny-default is preserved.
         assert!(content_on.contains("(deny default)"));
+        // With networking off, the keychain block supplies trustd itself.
+        assert!(content_on.contains("(allow mach-lookup (global-name \"com.apple.trustd\"))"));
+
+        // Keychain + network is a realistic production config. trustd is
+        // granted by the network block, so the keychain block must not
+        // emit it again (guards against duplicate Mach entries).
+        let dir_both = std::env::temp_dir().join("arapuca-test-profile-keychain-net");
+        let _ = std::fs::create_dir_all(&dir_both);
+        let both = ProfileData {
+            read_paths: vec!["/home/user/src".into()],
+            write_paths: vec![],
+            exec_paths: vec![],
+            control_socket: None,
+            llm_socket: None,
+            allow_network: true,
+            allow_keychain: true,
+        };
+        let content_both =
+            std::fs::read_to_string(generate_profile(&dir_both, &both).unwrap()).unwrap();
+        let trustd_count = content_both
+            .matches("(global-name \"com.apple.trustd\")")
+            .count();
+        assert_eq!(
+            trustd_count, 1,
+            "trustd must be granted exactly once when network and keychain are both on"
+        );
+        // Keychain files are still granted in the combined config.
+        assert!(content_both.contains("(allow file-read* (subpath \"/Library/Keychains\"))"));
 
         let _ = std::fs::remove_dir_all(&dir_off);
         let _ = std::fs::remove_dir_all(&dir_on);
+        let _ = std::fs::remove_dir_all(&dir_both);
     }
 
     #[test]

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -300,6 +300,19 @@ impl Sandbox for Darwin {
             }
         }
 
+        // When Keychain access is requested, add the user's login
+        // Keychain directory to read paths. The file-based login
+        // keychain is read directly by Security.framework; the
+        // securityd/trustd Mach services are granted by the profile.
+        if cfg.profile.allow_keychain {
+            if let Some(home) = std::env::var_os("HOME") {
+                let kc = std::path::Path::new(&home).join("Library/Keychains");
+                if kc.exists() {
+                    read_paths.push(canon(&kc));
+                }
+            }
+        }
+
         // Canonicalize cmd early so exec_paths and actual_cmd use
         // the same resolved path. Seatbelt does NOT resolve symlinks
         // in the target binary path for process-exec checks.
@@ -341,6 +354,7 @@ impl Sandbox for Darwin {
             control_socket,
             llm_socket,
             allow_network,
+            allow_keychain: cfg.profile.allow_keychain,
         };
 
         // Generate the Seatbelt profile.
@@ -393,6 +407,24 @@ impl Sandbox for Darwin {
                 entry.1 = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:\
                             /usr/local/sbin:/usr/sbin:/sbin"
                     .into();
+            }
+        }
+
+        // When Keychain access is enabled, point HOME at the caller's real
+        // home directory instead of the sandbox temp dir. The macOS
+        // Keychain search list is derived from HOME; with the default temp
+        // HOME the login keychain is absent from the search list and
+        // Keychain items cannot be found (reads fail as "item not found").
+        // Confinement is unaffected: access is bounded by the mount profile,
+        // not by $HOME, so an un-mounted home still yields EPERM.
+        if cfg.profile.allow_keychain {
+            if let Some(home) = std::env::var_os("HOME") {
+                let home = home.to_string_lossy().into_owned();
+                if let Some(entry) = env_vars.iter_mut().find(|(k, _)| k == "HOME") {
+                    entry.1 = home;
+                } else {
+                    env_vars.push(("HOME".into(), home));
+                }
             }
         }
 

--- a/src/platform/darwin/mod.rs
+++ b/src/platform/darwin/mod.rs
@@ -218,17 +218,26 @@ impl Sandbox for Darwin {
                 })?;
             }
 
-            let seatbelt_detail = if allow_network {
+            let network_detail = if allow_network {
                 "network=allowed"
             } else if proxy_mode {
                 "network=proxy-only"
             } else {
                 "network=denied"
             };
+            // Record Keychain access too: --allow-keychain widens the
+            // sandbox (extra Mach services and Keychain file reads), so
+            // it must leave an audit trail alongside the network mode.
+            let keychain_detail = if cfg.profile.allow_keychain {
+                "keychain=allowed"
+            } else {
+                "keychain=denied"
+            };
+            let seatbelt_detail = format!("{network_detail},{keychain_detail}");
             ctx.emit(AuditEvent::LayerApplied {
                 timestamp: ctx.timestamp(),
                 layer: SandboxLayer::Seatbelt,
-                detail: Some(crate::audit::LayerDetail::Other(seatbelt_detail.into())),
+                detail: Some(crate::audit::LayerDetail::Other(seatbelt_detail)),
             })?;
             ctx.emit(AuditEvent::LayerApplied {
                 timestamp: ctx.timestamp(),
@@ -300,19 +309,6 @@ impl Sandbox for Darwin {
             }
         }
 
-        // When Keychain access is requested, add the user's login
-        // Keychain directory to read paths. The file-based login
-        // keychain is read directly by Security.framework; the
-        // securityd/trustd Mach services are granted by the profile.
-        if cfg.profile.allow_keychain {
-            if let Some(home) = std::env::var_os("HOME") {
-                let kc = std::path::Path::new(&home).join("Library/Keychains");
-                if kc.exists() {
-                    read_paths.push(canon(&kc));
-                }
-            }
-        }
-
         // Canonicalize cmd early so exec_paths and actual_cmd use
         // the same resolved path. Seatbelt does NOT resolve symlinks
         // in the target binary path for process-exec checks.
@@ -337,6 +333,30 @@ impl Sandbox for Darwin {
                 if !exec_paths.contains(p) {
                     exec_paths.push(p.clone());
                 }
+            }
+        }
+
+        // When Keychain access is requested, add the user's login
+        // Keychain directory to read paths. The file-based login
+        // keychain is read directly by Security.framework; the
+        // securityd/trustd Mach services are granted by the profile.
+        //
+        // This runs after the allow_exec block on purpose: the
+        // Keychains directory only holds `.keychain-db` files and must
+        // never be granted process-exec, so it must not be copied into
+        // exec_paths above.
+        if cfg.profile.allow_keychain {
+            if let Some(home) = std::env::var_os("HOME") {
+                let kc = std::path::Path::new(&home).join("Library/Keychains");
+                if kc.exists() {
+                    read_paths.push(canon(&kc));
+                }
+            } else {
+                log::warn!(
+                    "--allow-keychain: HOME is unset, so the login Keychain \
+                     directory cannot be located; Keychain reads will fail. \
+                     Set HOME to the real home directory."
+                );
             }
         }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -187,9 +187,8 @@ pub struct Profile {
     ///
     /// The deny-default Seatbelt profile blocks the Mach services and
     /// files that `Security.framework` needs to read Keychain items,
-    /// so tools that authenticate via the login Keychain (e.g. Claude
-    /// Code's subscription OAuth token stored under
-    /// `Claude Code-credentials`) report "not logged in" inside the
+    /// so tools that authenticate via the login Keychain (e.g. stored
+    /// OAuth tokens) report "not logged in" inside the
     /// sandbox. When true, the profile additionally allows the
     /// `securityd`/`trustd` Mach lookups and read access to the
     /// Keychain database files so native Keychain authentication works.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -182,6 +182,28 @@ pub struct Profile {
     /// Only meaningful when outbound network is allowed (macOS baseline
     /// seccomp mode). Ignored on other platforms.
     pub allow_proxy_env: bool,
+    /// Grant the sandboxed process access to the macOS Keychain
+    /// (macOS only; ignored on other platforms).
+    ///
+    /// The deny-default Seatbelt profile blocks the Mach services and
+    /// files that `Security.framework` needs to read Keychain items,
+    /// so tools that authenticate via the login Keychain (e.g. Claude
+    /// Code's subscription OAuth token stored under
+    /// `Claude Code-credentials`) report "not logged in" inside the
+    /// sandbox. When true, the profile additionally allows the
+    /// `securityd`/`trustd` Mach lookups and read access to the
+    /// Keychain database files so native Keychain authentication works.
+    ///
+    /// On macOS this also points `HOME` at the launching user's real home
+    /// directory (the Keychain search list is derived from `HOME`; the
+    /// sandbox's default temp `HOME` omits the login keychain, so items
+    /// cannot be found otherwise). Confinement is unaffected — the mount
+    /// profile, not `$HOME`, bounds what is accessible.
+    ///
+    /// This widens the sandbox: the process can read any Keychain item
+    /// the invoking user can. Enable only for trusted tools that need
+    /// Keychain-backed credentials.
+    pub allow_keychain: bool,
 }
 
 /// Full configuration for launching a sandboxed process.


### PR DESCRIPTION
Adds an opt-in `--allow-keychain` flag so a trusted tool can authenticate against the macOS login Keychain from inside the sandbox.

The deny-default Seatbelt profile blocks the Mach services and files that `Security.framework` needs to read Keychain items, so tools that authenticate through the login Keychain report "not logged in".

On macOS the flag:

- grants the `securityd`/`trustd`/`ocspd` Mach lookups and read access to the Keychain files (`/Library/Keychains`, `/System/Library/Keychains`, `/private/var/db/mds`);
- mounts `~/Library/Keychains` read-only;
- sets `HOME` to the real home directory. The Keychain search list is derived from `HOME`; with the sandbox temp `HOME` the login keychain is not in the search list and items can't be found. Access is still bounded by the mount profile, not by `HOME`, so an un-mounted home still returns `EPERM`.

Ignored on non-macOS platforms.

Tested: `cargo test` (219, incl. a new profile test) and `cargo clippy` pass.