### PR TITLE
fix(windows): launch AppContainer processes reliably

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -872,7 +872,11 @@ fn build_env(cfg: &Config, tmp_dir: &Path) -> Vec<(String, String)> {
     let mut env: Vec<(String, String)> = crate::env::filter_caller_env(&cfg.env).passed;
     const OVERRIDDEN: &[&str] = &[
         "USERPROFILE",
+        "APPDATA",
         "LOCALAPPDATA",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "USERNAME",
         "TEMP",
         "TMP",
         "PATH",
@@ -893,12 +897,15 @@ fn build_env(cfg: &Config, tmp_dir: &Path) -> Vec<(String, String)> {
     }
 
     let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".into());
+    let profile = tmp_dir.to_string_lossy().into_owned();
+    let (home_drive, home_path) = split_windows_home(&profile);
 
-    env.push(("USERPROFILE".into(), tmp_dir.to_string_lossy().into_owned()));
-    env.push((
-        "LOCALAPPDATA".into(),
-        tmp_dir.to_string_lossy().into_owned(),
-    ));
+    env.push(("USERPROFILE".into(), profile.clone()));
+    env.push(("APPDATA".into(), profile.clone()));
+    env.push(("LOCALAPPDATA".into(), profile));
+    env.push(("HOMEDRIVE".into(), home_drive));
+    env.push(("HOMEPATH".into(), home_path));
+    env.push(("USERNAME".into(), "sandbox".into()));
     env.push(("TEMP".into(), tmp_dir.to_string_lossy().into_owned()));
     env.push(("TMP".into(), tmp_dir.to_string_lossy().into_owned()));
     env.push((
@@ -909,6 +916,25 @@ fn build_env(cfg: &Config, tmp_dir: &Path) -> Vec<(String, String)> {
     env.push(("LANG".into(), "C.UTF-8".into()));
 
     env
+}
+
+/// Split a Windows absolute path into `HOMEDRIVE` / `HOMEPATH` form.
+///
+/// Falls back to `C:` + the full path when no drive letter is present
+/// (for example a Volume GUID path used only in tests).
+fn split_windows_home(path: &str) -> (String, String) {
+    let bytes = path.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        let drive = path[..2].to_ascii_uppercase();
+        let rest = &path[2..];
+        let home_path = if rest.is_empty() {
+            r"\".to_string()
+        } else {
+            rest.to_string()
+        };
+        return (drive, home_path);
+    }
+    ("C:".into(), path.to_string())
 }
 
 // ─── Utilities ─────────────────────────────────────────────────────
@@ -1568,6 +1594,60 @@ mod tests {
             .collect();
         assert_eq!(profiles.len(), 1);
         assert_eq!(profiles[0].1, temp.to_string_lossy());
+    }
+
+    #[test]
+    fn caller_app_data_home_and_username_do_not_override_sandbox() {
+        let temp = Path::new(r"C:\sandbox-temp");
+        let config = Config {
+            profile: crate::Profile::default(),
+            socket_dir: PathBuf::new(),
+            task_id: "env-test".into(),
+            phase: "test".into(),
+            work_dir: None,
+            network_proxy_socket: None,
+            env: vec![
+                ("AppData".into(), r"C:\Users\host\AppData\Roaming".into()),
+                ("homedrive".into(), "D:".into()),
+                ("HomePath".into(), r"\Users\host".into()),
+                ("UserName".into(), "host-user".into()),
+            ],
+            audit_sink: None,
+            audit_verbosity: crate::audit::AuditVerbosity::Standard,
+            audit_principal: None,
+            audit_correlation_id: None,
+        };
+
+        let env = build_env(&config, temp);
+        let only = |name: &str| -> Vec<_> {
+            env.iter()
+                .filter(|(key, _)| key.eq_ignore_ascii_case(name))
+                .cloned()
+                .collect()
+        };
+
+        assert_eq!(
+            only("APPDATA"),
+            vec![("APPDATA".into(), temp.to_string_lossy().into_owned())]
+        );
+        assert_eq!(only("HOMEDRIVE"), vec![("HOMEDRIVE".into(), "C:".into())]);
+        assert_eq!(
+            only("HOMEPATH"),
+            vec![("HOMEPATH".into(), r"\sandbox-temp".into())]
+        );
+        assert_eq!(
+            only("USERNAME"),
+            vec![("USERNAME".into(), "sandbox".into())]
+        );
+    }
+
+    #[test]
+    fn split_windows_home_uses_drive_and_path() {
+        assert_eq!(
+            split_windows_home(r"C:\sandbox-temp"),
+            ("C:".into(), r"\sandbox-temp".into())
+        );
+        assert_eq!(split_windows_home(r"d:"), ("D:".into(), r"\".into()));
     }
 
     #[test]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -100,12 +100,7 @@ impl Sandbox for Windows {
         let env_block = encode_env_block(&env_vars);
         let mut cmdline = quote_args(cmd, args);
 
-        let work_dir: Option<Vec<u16>> = cfg.work_dir.as_ref().map(|p| {
-            p.as_os_str()
-                .encode_wide()
-                .chain(std::iter::once(0))
-                .collect()
-        });
+        let work_dir: Option<Vec<u16>> = cfg.work_dir.as_ref().map(|p| encode_work_dir(p));
 
         let stdio_handles = duplicate_stdio().inspect_err(cleanup_tmp)?;
         let mut handle_list: Vec<HANDLE> = stdio_handles
@@ -886,6 +881,10 @@ fn build_env(cfg: &Config, tmp_dir: &Path) -> Vec<(String, String)> {
     let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".into());
 
     env.push(("USERPROFILE".into(), tmp_dir.to_string_lossy().into_owned()));
+    env.push((
+        "LOCALAPPDATA".into(),
+        tmp_dir.to_string_lossy().into_owned(),
+    ));
     env.push(("TEMP".into(), tmp_dir.to_string_lossy().into_owned()));
     env.push(("TMP".into(), tmp_dir.to_string_lossy().into_owned()));
     env.push((
@@ -921,6 +920,28 @@ pub(crate) fn quote_args(cmd: &str, args: &[&str]) -> Vec<u16> {
         .encode_wide()
         .chain(std::iter::once(0))
         .collect()
+}
+
+/// Encode a working directory for `CreateProcessW`.
+///
+/// `Path::canonicalize` returns verbatim (`\\?\`) paths on Windows. Console
+/// programs such as `cmd.exe` interpret a verbatim drive path as a UNC path
+/// and silently fall back to the Windows directory. Convert the verbatim
+/// prefix back to its regular Win32 form before spawning the child.
+fn encode_work_dir(path: &Path) -> Vec<u16> {
+    use std::ffi::OsStr;
+
+    let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    let verbatim = OsStr::new(r"\\?\").encode_wide().collect::<Vec<_>>();
+    let verbatim_unc = OsStr::new(r"\\?\UNC\").encode_wide().collect::<Vec<_>>();
+    if wide.starts_with(&verbatim_unc) {
+        wide.drain(..verbatim_unc.len());
+        wide.splice(0..0, OsStr::new(r"\\").encode_wide());
+    } else if wide.starts_with(&verbatim) {
+        wide.drain(..verbatim.len());
+    }
+    wide.push(0);
+    wide
 }
 
 fn quote_arg(arg: &str, out: &mut String) {
@@ -1412,6 +1433,51 @@ mod tests {
     fn quote_null_terminated() {
         let result = quote_args("cmd", &[]);
         assert_eq!(*result.last().unwrap(), 0u16);
+    }
+
+    #[test]
+    fn work_dir_removes_verbatim_disk_prefix() {
+        let encoded = encode_work_dir(Path::new(r"\\?\C:\work tree"));
+        let decoded = String::from_utf16(&encoded[..encoded.len() - 1]).unwrap();
+        assert_eq!(decoded, r"C:\work tree");
+    }
+
+    #[test]
+    fn work_dir_converts_verbatim_unc_prefix() {
+        let encoded = encode_work_dir(Path::new(r"\\?\UNC\server\share\work"));
+        let decoded = String::from_utf16(&encoded[..encoded.len() - 1]).unwrap();
+        assert_eq!(decoded, r"\\server\share\work");
+    }
+
+    #[test]
+    fn work_dir_preserves_regular_path_and_terminates() {
+        let encoded = encode_work_dir(Path::new(r"C:\work"));
+        let decoded = String::from_utf16(&encoded[..encoded.len() - 1]).unwrap();
+        assert_eq!(decoded, r"C:\work");
+        assert_eq!(encoded.last(), Some(&0));
+    }
+
+    #[test]
+    fn child_env_sets_local_app_data_to_sandbox_temp() {
+        let temp = Path::new(r"C:\sandbox-temp");
+        let config = Config {
+            profile: crate::Profile::default(),
+            socket_dir: PathBuf::new(),
+            task_id: "env-test".into(),
+            phase: "test".into(),
+            work_dir: None,
+            network_proxy_socket: None,
+            env: Vec::new(),
+            audit_sink: None,
+            audit_verbosity: crate::audit::AuditVerbosity::Standard,
+            audit_principal: None,
+            audit_correlation_id: None,
+        };
+        let env = build_env(&config, temp);
+        assert!(
+            env.iter()
+                .any(|(key, value)| { key == "LOCALAPPDATA" && value == &temp.to_string_lossy() })
+        );
     }
 
     #[test]

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -870,6 +870,20 @@ fn rollback_appcontainer(
 
 fn build_env(cfg: &Config, tmp_dir: &Path) -> Vec<(String, String)> {
     let mut env: Vec<(String, String)> = crate::env::filter_caller_env(&cfg.env).passed;
+    const OVERRIDDEN: &[&str] = &[
+        "USERPROFILE",
+        "LOCALAPPDATA",
+        "TEMP",
+        "TMP",
+        "PATH",
+        "SystemRoot",
+        "LANG",
+    ];
+    env.retain(|(key, _)| {
+        !OVERRIDDEN
+            .iter()
+            .any(|managed| key.eq_ignore_ascii_case(managed))
+    });
 
     if let Some(ref proxy) = cfg.network_proxy_socket {
         env.push((
@@ -937,7 +951,12 @@ fn encode_work_dir(path: &Path) -> Vec<u16> {
     if wide.starts_with(&verbatim_unc) {
         wide.drain(..verbatim_unc.len());
         wide.splice(0..0, OsStr::new(r"\\").encode_wide());
-    } else if wide.starts_with(&verbatim) {
+    } else if wide.starts_with(&verbatim)
+        && wide.len() > verbatim.len() + 2
+        && (wide[verbatim.len()] >= b'A' as u16 && wide[verbatim.len()] <= b'Z' as u16
+            || wide[verbatim.len()] >= b'a' as u16 && wide[verbatim.len()] <= b'z' as u16)
+        && wide[verbatim.len() + 1] == b':' as u16
+    {
         wide.drain(..verbatim.len());
     }
     wide.push(0);
@@ -1450,6 +1469,14 @@ mod tests {
     }
 
     #[test]
+    fn work_dir_preserves_verbatim_volume_guid_path() {
+        let path = r"\\?\Volume{12345678-1234-1234-1234-123456789abc}\work";
+        let encoded = encode_work_dir(Path::new(path));
+        let decoded = String::from_utf16(&encoded[..encoded.len() - 1]).unwrap();
+        assert_eq!(decoded, path);
+    }
+
+    #[test]
     fn work_dir_preserves_regular_path_and_terminates() {
         let encoded = encode_work_dir(Path::new(r"C:\work"));
         let decoded = String::from_utf16(&encoded[..encoded.len() - 1]).unwrap();
@@ -1478,6 +1505,69 @@ mod tests {
             env.iter()
                 .any(|(key, value)| { key == "LOCALAPPDATA" && value == &temp.to_string_lossy() })
         );
+    }
+
+    #[test]
+    fn caller_local_app_data_does_not_override_sandbox() {
+        let temp = Path::new(r"C:\sandbox-temp");
+        let config = Config {
+            profile: crate::Profile::default(),
+            socket_dir: PathBuf::new(),
+            task_id: "env-test".into(),
+            phase: "test".into(),
+            work_dir: None,
+            network_proxy_socket: None,
+            env: vec![("localappdata".into(), r"C:\Users\host\AppData\Local".into())],
+            audit_sink: None,
+            audit_verbosity: crate::audit::AuditVerbosity::Standard,
+            audit_principal: None,
+            audit_correlation_id: None,
+        };
+
+        let values: Vec<_> = build_env(&config, temp)
+            .into_iter()
+            .filter(|(key, _)| key.eq_ignore_ascii_case("LOCALAPPDATA"))
+            .collect();
+        assert_eq!(
+            values,
+            vec![("LOCALAPPDATA".into(), temp.to_string_lossy().into_owned())]
+        );
+    }
+
+    #[test]
+    fn caller_path_and_user_profile_do_not_override_sandbox() {
+        let temp = Path::new(r"C:\sandbox-temp");
+        let config = Config {
+            profile: crate::Profile::default(),
+            socket_dir: PathBuf::new(),
+            task_id: "env-test".into(),
+            phase: "test".into(),
+            work_dir: None,
+            network_proxy_socket: None,
+            env: vec![
+                ("Path".into(), r"C:\host-bin".into()),
+                ("userprofile".into(), r"C:\Users\host".into()),
+            ],
+            audit_sink: None,
+            audit_verbosity: crate::audit::AuditVerbosity::Standard,
+            audit_principal: None,
+            audit_correlation_id: None,
+        };
+
+        let env = build_env(&config, temp);
+        let paths: Vec<_> = env
+            .iter()
+            .filter(|(key, _)| key.eq_ignore_ascii_case("PATH"))
+            .collect();
+        assert_eq!(paths.len(), 1);
+        assert!(!paths[0].1.contains("host-bin"));
+
+        let profiles: Vec<_> = env
+            .iter()
+            .filter(|(key, _)| key.eq_ignore_ascii_case("USERPROFILE"))
+            .collect();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].1, temp.to_string_lossy());
     }
 
     #[test]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -228,7 +228,10 @@ pub struct Config {
     /// Caller-supplied environment variables for the subprocess.
     /// Filtered by the platform launcher before use: ARAPUCA_*,
     /// LD_*, DYLD_*, and other dangerous names are silently dropped.
-    /// If the same key is added multiple times, the last value wins.
+    /// Callers should not provide duplicate keys. On Windows, entries are
+    /// sorted case-insensitively and process lookup uses the first matching
+    /// entry. Launcher-managed keys are removed and re-added so sandbox
+    /// values take precedence.
     pub env: Vec<(String, String)>,
     /// Optional audit event sink. When None, no events are emitted
     /// and zero audit overhead is incurred.


### PR DESCRIPTION
## Summary

Fix Windows AppContainer launches failing with `CreateProcessW` error 203 and preserve the requested working directory for console programs.

## Root cause

- AppContainer process creation requires `LOCALAPPDATA` in an explicit environment block. The Windows launcher replaced the parent environment but omitted it, causing `ERROR_ENVVAR_NOT_FOUND` (203) whenever mounts selected the AppContainer path.
- `Path::canonicalize()` returns `\\?\` verbatim paths on Windows. Passing one as `lpCurrentDirectory` makes `cmd.exe` interpret the drive path as UNC and fall back to the Windows directory.

## Fix

- Set `LOCALAPPDATA` to the sandbox temp directory (no host profile disclosure).
- Convert verbatim disk/UNC prefixes to regular Win32 form only for `lpCurrentDirectory`.
- Add focused unit coverage.

## Validation

On Windows 11, before:

```text
arapuca run: launch failed: process: CreateProcessW: The system could not find the environment option that was entered. (os error 203)
```

After, a read-only AppContainer mount successfully runs `cmd.exe`, and `%CD%` is the requested directory. `cargo test platform::windows::tests` passes (16 tests).