### PR TITLE
fix: repair release build failures on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ vm-agent = []
 microvm = ["dep:reqwest", "dep:krun-sys", "dep:openssl", "dep:gpt", "dep:nbd"]
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = ">= 0.2, < 0.2.188"
 nix = { version = "0.31", features = ["fs", "process", "sched", "signal", "user"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -460,6 +460,7 @@ fn env_enforcement_end_to_end() {
     cfg.profile
         .write_paths
         .push(std::path::PathBuf::from("/tmp"));
+    cfg.profile.allow_exec = true;
     cfg.env = vec![
         ("SAFE_VAR".into(), "hello".into()),
         ("LD_PRELOAD".into(), "/evil.so".into()),


### PR DESCRIPTION
The env_enforcement_end_to_end integration test runs /usr/bin/env inside the sandbox but never set allow_exec, which worked before Landlock started enforcing execution permissions. Add the missing flag.

Pin libc below 0.2.188 which changed the ioctl request parameter type and removed __rlimit_resource_t on musl, breaking the static musl build.