### PR TITLE
fix: pin libc below 0.2.187 for musl ioctl compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ vm-agent = []
 microvm = ["dep:reqwest", "dep:krun-sys", "dep:openssl", "dep:gpt", "dep:nbd"]
 
 [target.'cfg(unix)'.dependencies]
-libc = ">= 0.2, < 0.2.188"
+libc = ">= 0.2, < 0.2.187"
 nix = { version = "0.31", features = ["fs", "process", "sched", "signal", "user"] }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
The previous pin (< 0.2.188) was insufficient — libc 0.2.187 already changed the ioctl request parameter type to Ioctl (i32 on musl, breaking our c_ulong casts) and removed __rlimit_resource_t.
