### PR TITLE
fix: use portable types for ioctl and prlimit64 on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ vm-agent = []
 microvm = ["dep:reqwest", "dep:krun-sys", "dep:openssl", "dep:gpt", "dep:nbd"]
 
 [target.'cfg(unix)'.dependencies]
-libc = ">= 0.2, < 0.2.187"
+libc = "0.2"
 nix = { version = "0.31", features = ["fs", "process", "sched", "signal", "user"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -483,16 +483,16 @@ impl Sandbox for Linux {
             // Copy parent's terminal size (fallback to 24x80).
             let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
             // SAFETY: TIOCGWINSZ on stdin.
-            if unsafe { libc::ioctl(0, libc::TIOCGWINSZ, &mut ws) } == 0
+            if unsafe { libc::ioctl(0, libc::TIOCGWINSZ as libc::Ioctl, &mut ws) } == 0
                 && ws.ws_row > 0
                 && ws.ws_col > 0
             {
                 // SAFETY: TIOCSWINSZ on the PTY master.
-                unsafe { libc::ioctl(master, libc::TIOCSWINSZ, &ws) };
+                unsafe { libc::ioctl(master, libc::TIOCSWINSZ as libc::Ioctl, &ws) };
             } else {
                 ws.ws_row = 24;
                 ws.ws_col = 80;
-                unsafe { libc::ioctl(master, libc::TIOCSWINSZ, &ws) };
+                unsafe { libc::ioctl(master, libc::TIOCSWINSZ as libc::Ioctl, &ws) };
             }
 
             (Some(master), Some(slave))
@@ -899,7 +899,7 @@ impl Sandbox for Linux {
                     // SAFETY: TIOCSCTTY on the slave PTY. arg=0: do not
                     // steal from another session (the slave is always
                     // unowned after openpty + setsid).
-                    if libc::ioctl(sfd, libc::TIOCSCTTY as libc::c_ulong, 0i32) != 0 {
+                    if libc::ioctl(sfd, libc::TIOCSCTTY as libc::Ioctl, 0i32) != 0 {
                         return Err(std::io::Error::last_os_error());
                     }
                     if libc::dup2(sfd, 0) == -1 {

--- a/src/rlimit.rs
+++ b/src/rlimit.rs
@@ -35,16 +35,20 @@ use crate::{Error, Profile};
 /// Returns an error if any `prlimit64` call fails.
 #[must_use = "rlimit errors must be handled"]
 pub fn apply(profile: &Profile) -> crate::Result<()> {
-    set_rlimit(libc::RLIMIT_CORE, 0, "RLIMIT_CORE")?;
+    set_rlimit(libc::RLIMIT_CORE as _, 0, "RLIMIT_CORE")?;
     if profile.max_file_size_mb > 0 {
         let bytes = profile
             .max_file_size_mb
             .checked_mul(1024 * 1024)
             .ok_or_else(|| Error::Rlimit("max_file_size_mb overflow".into()))?;
-        set_rlimit(libc::RLIMIT_FSIZE, bytes, "RLIMIT_FSIZE")?;
+        set_rlimit(libc::RLIMIT_FSIZE as _, bytes, "RLIMIT_FSIZE")?;
     }
     if profile.max_open_files > 0 {
-        set_rlimit(libc::RLIMIT_NOFILE, profile.max_open_files, "RLIMIT_NOFILE")?;
+        set_rlimit(
+            libc::RLIMIT_NOFILE as _,
+            profile.max_open_files,
+            "RLIMIT_NOFILE",
+        )?;
     }
     Ok(())
 }
@@ -55,34 +59,34 @@ pub fn apply(profile: &Profile) -> crate::Result<()> {
 /// `ARAPUCA_RLIMIT_CPU`, `ARAPUCA_RLIMIT_FSIZE`, and `ARAPUCA_RLIMIT_NOFILE`
 /// from the environment.
 pub fn apply_from_env() -> crate::Result<()> {
-    set_rlimit(libc::RLIMIT_CORE, 0, "RLIMIT_CORE")?;
+    set_rlimit(libc::RLIMIT_CORE as _, 0, "RLIMIT_CORE")?;
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_AS")? {
-        set_rlimit(libc::RLIMIT_AS, v, "RLIMIT_AS")?;
+        set_rlimit(libc::RLIMIT_AS as _, v, "RLIMIT_AS")?;
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_NPROC")? {
-        set_rlimit(libc::RLIMIT_NPROC, v, "RLIMIT_NPROC")?;
+        set_rlimit(libc::RLIMIT_NPROC as _, v, "RLIMIT_NPROC")?;
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_CPU")? {
-        set_rlimit(libc::RLIMIT_CPU, v, "RLIMIT_CPU")?;
+        set_rlimit(libc::RLIMIT_CPU as _, v, "RLIMIT_CPU")?;
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_FSIZE")? {
-        set_rlimit(libc::RLIMIT_FSIZE, v, "RLIMIT_FSIZE")?;
+        set_rlimit(libc::RLIMIT_FSIZE as _, v, "RLIMIT_FSIZE")?;
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_NOFILE")? {
-        set_rlimit(libc::RLIMIT_NOFILE, v, "RLIMIT_NOFILE")?;
+        set_rlimit(libc::RLIMIT_NOFILE as _, v, "RLIMIT_NOFILE")?;
     }
     Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn set_rlimit(resource: libc::__rlimit_resource_t, value: u64, name: &str) -> crate::Result<()> {
+fn set_rlimit(resource: u32, value: u64, name: &str) -> crate::Result<()> {
     let rlim = libc::rlimit64 {
         rlim_cur: value,
         rlim_max: value,
     };
     // SAFETY: prlimit64 with pid=0 targets the calling process.
     // The rlimit struct is valid and on the stack.
-    let ret = unsafe { libc::prlimit64(0, resource, &rlim, std::ptr::null_mut()) };
+    let ret = unsafe { libc::prlimit64(0, resource as _, &rlim, std::ptr::null_mut()) };
     if ret != 0 {
         return Err(Error::Rlimit(format!(
             "{name}: {}",
@@ -141,15 +145,15 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn apply_does_not_set_rlimit_as_or_nproc() {
-        let read_rlimit = |resource| {
+        let read_rlimit = |resource: libc::c_uint| {
             let mut rlim: libc::rlimit64 = unsafe { std::mem::zeroed() };
             // SAFETY: prlimit64 with pid=0 reads the current process limit.
-            unsafe { libc::prlimit64(0, resource, std::ptr::null(), &mut rlim) };
+            unsafe { libc::prlimit64(0, resource as _, std::ptr::null(), &mut rlim) };
             rlim.rlim_cur
         };
 
-        let as_before = read_rlimit(libc::RLIMIT_AS);
-        let nproc_before = read_rlimit(libc::RLIMIT_NPROC);
+        let as_before = read_rlimit(libc::RLIMIT_AS as _);
+        let nproc_before = read_rlimit(libc::RLIMIT_NPROC as _);
 
         let profile = Profile {
             max_memory_mb: 256,
@@ -158,8 +162,8 @@ mod tests {
         };
         apply(&profile).unwrap();
 
-        let as_after = read_rlimit(libc::RLIMIT_AS);
-        let nproc_after = read_rlimit(libc::RLIMIT_NPROC);
+        let as_after = read_rlimit(libc::RLIMIT_AS as _);
+        let nproc_after = read_rlimit(libc::RLIMIT_NPROC as _);
 
         assert_eq!(as_before, as_after, "apply() must not modify RLIMIT_AS");
         assert_eq!(
@@ -176,7 +180,7 @@ mod tests {
 
         let mut rlim: libc::rlimit64 = unsafe { std::mem::zeroed() };
         // SAFETY: prlimit64 with pid=0 reads the current process limit.
-        unsafe { libc::prlimit64(0, libc::RLIMIT_CORE, std::ptr::null(), &mut rlim) };
+        unsafe { libc::prlimit64(0, libc::RLIMIT_CORE as _, std::ptr::null(), &mut rlim) };
         assert_eq!(rlim.rlim_cur, 0, "apply() must set RLIMIT_CORE soft to 0");
         assert_eq!(rlim.rlim_max, 0, "apply() must set RLIMIT_CORE hard to 0");
     }

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -34,21 +34,21 @@ const IOC_WRITE: u32 = 1;
 const IOC_READ: u32 = 2;
 const IOC_TYPE: u32 = b'!' as u32;
 
-const fn ioc(dir: u32, nr: u32, size: u32) -> libc::c_ulong {
-    ((dir << 30) | (IOC_TYPE << 8) | nr | (size << 16)) as libc::c_ulong
+const fn ioc(dir: u32, nr: u32, size: u32) -> libc::Ioctl {
+    ((dir << 30) | (IOC_TYPE << 8) | nr | (size << 16)) as libc::Ioctl
 }
 
 /// `ioctl(fd, SECCOMP_IOCTL_NOTIF_RECV, &notif)` — receive a notification.
-const SECCOMP_IOCTL_NOTIF_RECV: libc::c_ulong = ioc(IOC_WRITE | IOC_READ, 0, 80);
+const SECCOMP_IOCTL_NOTIF_RECV: libc::Ioctl = ioc(IOC_WRITE | IOC_READ, 0, 80);
 
 /// `ioctl(fd, SECCOMP_IOCTL_NOTIF_SEND, &resp)` — send a response.
-const SECCOMP_IOCTL_NOTIF_SEND: libc::c_ulong = ioc(IOC_WRITE | IOC_READ, 1, 24);
+const SECCOMP_IOCTL_NOTIF_SEND: libc::Ioctl = ioc(IOC_WRITE | IOC_READ, 1, 24);
 
 /// `ioctl(fd, SECCOMP_IOCTL_NOTIF_ID_VALID, &id)` — check if notification is still valid.
 /// Kernel 5.17+ uses `_IOW`; kernels 5.0–5.16 use `_IOR`. The 5.17+
 /// kernel accepts both, so we try the new one first and fall back.
-const SECCOMP_IOCTL_NOTIF_ID_VALID_NEW: libc::c_ulong = ioc(IOC_WRITE, 2, 8);
-const SECCOMP_IOCTL_NOTIF_ID_VALID_OLD: libc::c_ulong = ioc(IOC_READ, 2, 8);
+const SECCOMP_IOCTL_NOTIF_ID_VALID_NEW: libc::Ioctl = ioc(IOC_WRITE, 2, 8);
+const SECCOMP_IOCTL_NOTIF_ID_VALID_OLD: libc::Ioctl = ioc(IOC_READ, 2, 8);
 
 // ─── BPF construction ─────────────────────────────────────────────
 


### PR DESCRIPTION
The libc crate defines ioctl's request parameter as Ioctl (c_int on musl, c_ulong on glibc) and prlimit64's resource parameter as __rlimit_resource_t (glibc-only). Cast ioctl requests through libc::Ioctl and rlimit resource constants through `as _` so both glibc and musl targets compile.

Removes the libc version pin since the code is now compatible with the latest libc (0.2.189).