### PR TITLE
fix(sandbox): don't grant read access to host /tmp by default

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -525,9 +525,10 @@ pub fn default_sandbox_paths() -> (Vec<PathBuf>, Vec<PathBuf>) {
         PathBuf::from("/dev/zero"),
         PathBuf::from("/dev/urandom"),
         PathBuf::from("/dev/random"),
-        // Temp directory (read-only — the private per-task temp dir
-        // is added as a write path by the launcher).
-        PathBuf::from("/tmp"),
+        // NOTE: /tmp is intentionally NOT granted by default — it is
+        // host-shared and would leak any secret placed there by other
+        // processes/users. Callers must opt in explicitly via
+        // `-v /tmp/some-subdir` (or similar) if they need it visible.
     ];
     let write = Vec::new();
     (read, write)
@@ -1076,8 +1077,16 @@ mod tests {
         assert!(read.iter().any(|p| p == Path::new("/usr")));
         assert!(read.iter().any(|p| p == Path::new("/bin")));
         assert!(read.iter().any(|p| p == Path::new("/dev/null")));
-        assert!(read.iter().any(|p| p == Path::new("/tmp")));
         assert!(write.is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn default_sandbox_paths_linux_excludes_tmp() {
+        // /tmp is host-shared; it must not be granted by default or a
+        // sandboxed process can read secrets left there by others.
+        let (read, _write) = default_sandbox_paths();
+        assert!(!read.iter().any(|p| p == Path::new("/tmp")));
     }
 
     #[cfg(target_os = "linux")]

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -916,18 +916,32 @@ fn cwd_file_not_directory_rejected() {
 }
 
 #[test]
-fn cwd_with_default_paths() {
+fn cwd_tmp_rejected_without_explicit_grant() {
+    // /tmp is intentionally NOT a default read path (host-shared temp
+    // dirs must not be visible unless explicitly granted via -v).
+    let status = Command::new(arapuca_bin())
+        .args(["run", "--cwd", "/tmp", "--", "/bin/pwd"])
+        .status()
+        .unwrap();
+    assert!(
+        !status.success(),
+        "--cwd /tmp should be rejected without an explicit -v grant"
+    );
+}
+
+#[test]
+fn cwd_tmp_with_explicit_grant() {
     let expected = std::path::PathBuf::from("/tmp").canonicalize().unwrap();
     let expected_str = expected.to_str().unwrap();
 
     let output = Command::new(arapuca_bin())
-        .args(["run", "--cwd", "/tmp", "--", "/bin/pwd"])
+        .args(["run", "--cwd", "/tmp", "-v", "/tmp", "--", "/bin/pwd"])
         .output()
         .unwrap();
 
     assert!(
         output.status.success(),
-        "--cwd /tmp should work via default read paths"
+        "--cwd /tmp should work once /tmp is explicitly granted via -v"
     );
     assert_eq!(
         String::from_utf8_lossy(&output.stdout).trim(),


### PR DESCRIPTION
## Summary

`default_sandbox_paths()` unconditionally adds `/tmp` to every sandbox's Linux read allowlist, and there's no CLI flag to opt out of it. Since `/tmp` is shared across every user and process on the host, this lets a sandboxed command read anything left there by something else on the machine — other users' scratch files, other tools' temp data, etc.

## Repro

```
mkdir -p /tmp/some-workspace
echo secret > /tmp/some-other-unrelated-dir/secret.txt   # nothing to do with the sandboxed job

arapuca run -v /tmp/some-workspace -- cat /tmp/some-other-unrelated-dir/secret.txt
# prints "secret" instead of being denied, even though only
# /tmp/some-workspace was ever granted
```

Same result for a file placed directly alongside the granted workspace directory (i.e. a sibling under `/tmp`, not just a fully unrelated subtree) — anything under `/tmp` is readable regardless of what `-v` flags are passed.

## Fix

Remove the hardcoded `/tmp` entry from the default read list (`src/env.rs`). A caller that wants a temp directory visible inside the jail now has to grant it explicitly — e.g. `-v $(mktemp -d)` for a private per-task scratch dir — so the real host `/tmp` is never implicitly readable.

## Tests

- Removed the assertion that `/tmp` is a default read path; added `default_sandbox_paths_linux_excludes_tmp` asserting it is not.
- Split `cwd_with_default_paths` into `cwd_tmp_rejected_without_explicit_grant` (new negative case) and `cwd_tmp_with_explicit_grant` (same original assertion, now with an explicit `-v /tmp`).
- Full suite passes on top of current `main`: 402 unit tests, all integration test binaries, except `tests/adversarial.rs::seccomp_allows_unix_socket`, which fails identically before and after this change (a Python interpreter path-resolution error specific to my sandbox environment — unrelated to sandbox path policy; confirmed by running it against unpatched `main` directly).

Happy to adjust the approach if you'd rather keep a private-tmp default via some other mechanism (e.g. auto-provisioning a fresh empty directory per invocation instead of removing the default outright) — flagging this mainly because the current behavior is a real, silent read-access gap for anyone using the default policy as their security boundary.