### PR TITLE
unotify: read host PID before installing USER_NOTIF filter

### DIFF
--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -339,6 +339,8 @@ fn main() {
         // PID namespace: unshare + fork between bridge and seccomp.
         // The parent (in host PID ns) stays as a signal relay; the
         // child (PID 1 in new ns) continues to seccomp + exec.
+        #[cfg(seccomp_supported)]
+        let mut pidns_host_pid: Option<i32> = None;
         if std::env::var("ARAPUCA_PID_NS").as_deref() == Ok("1") {
             let pid_report_fd: Option<i32> = std::env::var("ARAPUCA_PID_REPORT_FD")
                 .ok()
@@ -360,12 +362,16 @@ fn main() {
             audit_layer(audit_fd, "PidNamespace", true, None);
 
             // Parent never returns; child continues to seccomp.
-            let liveness_fd = arapuca::pidns::fork_into_pidns(
+            let (liveness_fd, _host_pid) = arapuca::pidns::fork_into_pidns(
                 audit_fd,
                 dns_audit_fd,
                 unotify_audit_fd,
                 pid_report_fd,
             );
+            #[cfg(seccomp_supported)]
+            {
+                pidns_host_pid = Some(_host_pid);
+            }
 
             // Child: re-set pdeathsig (fork clears it). The
             // getppid() race check is skipped inside the PID
@@ -416,15 +422,18 @@ fn main() {
                         config.audit_file_access,
                         config.audit_network,
                     );
+                    // The host PID is needed by the supervisor for
+                    // pidfd_open(). In a PID namespace, getpid() returns
+                    // the namespace-local PID (1), so we use the host PID
+                    // piped from fork_into_pidns(). Outside a PID namespace,
+                    // read_host_pid() reads /proc/self/stat — must happen
+                    // BEFORE install_unotify_filter() because the filter
+                    // intercepts openat and would deadlock.
+                    let host_pid = pidns_host_pid.unwrap_or_else(arapuca::unotify::read_host_pid);
                     match arapuca::unotify::build_unotify_bpf(&syscalls)
                         .and_then(|bpf| arapuca::unotify::install_unotify_filter(&bpf))
                     {
                         Ok(listener_fd) => {
-                            // Send the FD number via write() instead of
-                            // Send host PID + listener FD number via
-                            // write() — sendmsg is intercepted by the
-                            // USER_NOTIF filter we just installed.
-                            let host_pid = arapuca::unotify::read_host_pid();
                             let mut msg = [0u8; 8];
                             msg[..4].copy_from_slice(&host_pid.to_ne_bytes());
                             msg[4..].copy_from_slice(&listener_fd.to_ne_bytes());

--- a/src/pidns.rs
+++ b/src/pidns.rs
@@ -40,7 +40,7 @@ pub fn fork_into_pidns(
     dns_audit_fd: Option<i32>,
     unotify_audit_fd: Option<i32>,
     pid_report_fd: Option<i32>,
-) -> Option<i32> {
+) -> (Option<i32>, i32) {
     // Liveness pipe: parent holds write end, child reads it after
     // prctl(PR_SET_PDEATHSIG) to detect if the parent already died.
     // O_NONBLOCK so check_parent_liveness can read without fcntl.
@@ -48,6 +48,19 @@ pub fn fork_into_pidns(
     if unsafe { libc::pipe2(pipe_fds.as_mut_ptr(), libc::O_CLOEXEC | libc::O_NONBLOCK) } != 0 {
         write_stderr(&format!(
             "arapuca: pidns liveness pipe: {}\n",
+            std::io::Error::last_os_error()
+        ));
+        unsafe { libc::_exit(1) };
+    }
+
+    // Host-PID pipe: parent writes the child's host PID so the child
+    // can discover it without reading /proc/self/stat (which Landlock
+    // may block in strict mode). Blocking (no O_NONBLOCK) — the child
+    // reads exactly 4 bytes before continuing.
+    let mut pid_pipe = [0i32; 2];
+    if unsafe { libc::pipe2(pid_pipe.as_mut_ptr(), libc::O_CLOEXEC) } != 0 {
+        write_stderr(&format!(
+            "arapuca: pidns host-pid pipe: {}\n",
             std::io::Error::last_os_error()
         ));
         unsafe { libc::_exit(1) };
@@ -73,7 +86,21 @@ pub fn fork_into_pidns(
         // Close the liveness pipe write end — only the parent should
         // hold it. Without this, EOF never fires on the read end.
         unsafe { libc::close(pipe_fds[1]) };
-        return Some(pipe_fds[0]);
+
+        // Read host PID from parent relay. The child's getpid()
+        // returns 1 (namespace-local), but the unotify supervisor
+        // needs the host PID for pidfd_open().
+        unsafe { libc::close(pid_pipe[1]) };
+        let mut pid_buf = [0u8; 4];
+        let n = unsafe { libc::read(pid_pipe[0], pid_buf.as_mut_ptr().cast(), 4) };
+        unsafe { libc::close(pid_pipe[0]) };
+        let host_pid = if n == 4 {
+            i32::from_ne_bytes(pid_buf)
+        } else {
+            unsafe { libc::getpid() }
+        };
+
+        return (Some(pipe_fds[0]), host_pid);
     }
 
     // ── Parent: signal relay + waitpid ────────────────────────────
@@ -81,6 +108,18 @@ pub fn fork_into_pidns(
     unsafe { libc::close(pipe_fds[0]) };
     // Write end (pipe_fds[1]) is intentionally leaked — it closes
     // on _exit, causing EOF on the child's read end.
+
+    // Send host PID to child before entering the relay loop.
+    unsafe { libc::close(pid_pipe[0]) };
+    let pid_bytes = child_pid.to_ne_bytes();
+    let _ = unsafe {
+        libc::write(
+            pid_pipe[1],
+            pid_bytes.as_ptr().cast::<libc::c_void>(),
+            pid_bytes.len(),
+        )
+    };
+    unsafe { libc::close(pid_pipe[1]) };
 
     // This path never returns.
     parent_relay(

--- a/src/selfexec.rs
+++ b/src/selfexec.rs
@@ -219,8 +219,9 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                             audit_layer(audit_fd, "UnotifySupervisor", true, None);
                             Some(fds)
                         }
-                        Err(_) => {
-                            audit_layer(audit_fd, "UnotifySupervisor", false, None);
+                        Err(e) => {
+                            audit_layer(audit_fd, "UnotifySupervisor", false, Some(&e.to_string()));
+                            write_stderr(&format!("arapuca: selfexec: unotify supervisor: {e}\n"));
                             None
                         }
                     }
@@ -316,6 +317,8 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
     }
 
     // ── PID namespace ────────────────────────────────────────────
+    #[cfg(seccomp_supported)]
+    let mut pidns_host_pid: Option<i32> = None;
     if std::env::var("ARAPUCA_PID_NS").as_deref() == Ok("1") {
         let pid_report_fd: Option<i32> = std::env::var("ARAPUCA_PID_REPORT_FD")
             .ok()
@@ -336,8 +339,12 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
         }
         audit_layer(audit_fd, "PidNamespace", true, None);
 
-        let liveness_fd =
+        let (liveness_fd, _host_pid) =
             crate::pidns::fork_into_pidns(audit_fd, dns_audit_fd, unotify_audit_fd, pid_report_fd);
+        #[cfg(seccomp_supported)]
+        {
+            pidns_host_pid = Some(_host_pid);
+        }
 
         let ret = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
         if ret != 0 {
@@ -379,9 +386,18 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
             if let Some(ref config) = unotify_config {
                 let syscalls =
                     crate::unotify::target_syscalls(config.audit_file_access, config.audit_network);
-                if let Ok(bpf) = crate::unotify::build_unotify_bpf(&syscalls) {
-                    if let Ok(listener_fd) = crate::unotify::install_unotify_filter(&bpf) {
-                        let host_pid = crate::unotify::read_host_pid();
+                // The host PID is needed by the supervisor for
+                // pidfd_open(). In a PID namespace, getpid() returns
+                // the namespace-local PID (1), so we use the host PID
+                // piped from fork_into_pidns(). Outside a PID namespace,
+                // read_host_pid() reads /proc/self/stat — must happen
+                // BEFORE install_unotify_filter() because the filter
+                // intercepts openat and would deadlock.
+                let host_pid = pidns_host_pid.unwrap_or_else(crate::unotify::read_host_pid);
+                match crate::unotify::build_unotify_bpf(&syscalls)
+                    .and_then(|bpf| crate::unotify::install_unotify_filter(&bpf))
+                {
+                    Ok(listener_fd) => {
                         let mut msg = [0u8; 8];
                         msg[..4].copy_from_slice(&host_pid.to_ne_bytes());
                         msg[4..].copy_from_slice(&listener_fd.to_ne_bytes());
@@ -395,16 +411,17 @@ fn run_wrapper_path(argc: libc::c_int, argv: *const *const libc::c_char) -> ! {
                         unsafe {
                             libc::close(fds.socketpair_parent);
                         }
-                    } else {
+                    }
+                    Err(e) => {
+                        write_stderr(&format!("arapuca: selfexec: unotify filter: {e}\n"));
                         unsafe { libc::close(fds.socketpair_parent) };
                     }
-                } else {
-                    unsafe { libc::close(fds.socketpair_parent) };
                 }
             } else {
                 unsafe { libc::close(fds.socketpair_parent) };
             }
         } else {
+            write_stderr("arapuca: selfexec: unotify supervisor readiness timeout\n");
             unsafe {
                 libc::close(fds.readiness_read);
                 libc::close(fds.socketpair_parent);

--- a/src/unotify.rs
+++ b/src/unotify.rs
@@ -1030,8 +1030,9 @@ pub struct UnotifyFds {
 ///
 /// The supervisor is forked BEFORE any seccomp filters are installed
 /// to avoid inheriting the USER_NOTIF filter (which would deadlock
-/// on the supervisor's own openat calls). The listener FD is passed
-/// to the supervisor via SCM_RIGHTS after filter installation.
+/// on the supervisor's own openat calls). The listener FD number is
+/// sent to the supervisor via write() on a socketpair; the supervisor
+/// duplicates it via pidfd_getfd().
 ///
 /// Uses a **deferred readiness protocol**: the readiness pipe is
 /// returned to the caller, not polled internally. The caller must:
@@ -1050,7 +1051,7 @@ pub fn fork_unotify_supervisor(
     audit_write_fd: RawFd,
     seccomp_debug: bool,
 ) -> crate::Result<UnotifyFds> {
-    // Create Unix socketpair for SCM_RIGHTS FD passing.
+    // Create Unix socketpair for PID + FD number passing.
     let mut sv = [0i32; 2];
     if unsafe {
         libc::socketpair(


### PR DESCRIPTION
read_host_pid() opens /proc/self/stat via openat, which is one of the syscalls intercepted by the USER_NOTIF seccomp filter. When called after install_unotify_filter(), the wrapper deadlocks: the openat is suspended waiting for the supervisor to respond, but the supervisor is blocked on the socketpair waiting for the listener FD that the wrapper cannot send yet.

Move the call before filter installation so the openat completes unintercepted. The host PID value does not depend on the filter.
