### PR TITLE
ffi: expose allow_exec on profile

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -200,6 +200,25 @@ void arapuca_profile_set_max_file_size_mb(struct arapuca_ArapucaProfile *profile
 void arapuca_profile_set_max_open_files(struct arapuca_ArapucaProfile *profile, uint64_t n);
 
 /**
+ * Enable/disable exec permission for sandboxed processes.
+ *
+ * When enabled, read paths gain the Landlock Execute access right,
+ * allowing execve on any binary reachable through them. Write paths
+ * also gain Execute (they receive full access). When disabled (the
+ * default), only the target binary and the ELF interpreter are
+ * executable.
+ *
+ * Scripts that use a shebang (e.g. #!/usr/bin/env python3) require
+ * allow_exec = true because the kernel's script interpreter
+ * resolution needs Execute on the interpreter binary, not just the
+ * script itself.
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_allow_exec(struct arapuca_ArapucaProfile *profile, bool enabled);
+
+/**
  * Enable/disable network namespace isolation.
  *
  * # Safety

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -221,6 +221,33 @@ pub unsafe extern "C" fn arapuca_profile_set_max_open_files(profile: *mut Arapuc
     }
 }
 
+/// Enable/disable exec permission for sandboxed processes.
+///
+/// When enabled, read paths gain the Landlock `Execute` access right,
+/// allowing `execve` on any binary reachable through them. Write
+/// paths also gain Execute (they receive full access). When disabled
+/// (the default), only the target binary and the ELF interpreter are
+/// executable.
+///
+/// Scripts that use a shebang (e.g. `#!/usr/bin/env python3`) require
+/// `allow_exec = true` because the kernel's script interpreter
+/// resolution needs Execute on the interpreter binary, not just the
+/// script itself.
+///
+/// # Safety
+/// `profile` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_allow_exec(
+    profile: *mut ArapucaProfile,
+    enabled: bool,
+) {
+    if let Some(profile) = unsafe { profile.as_mut() } {
+        if let Some(inner) = profile.inner.as_mut() {
+            inner.allow_exec = enabled;
+        }
+    }
+}
+
 /// Enable/disable network namespace isolation.
 ///
 /// # Safety


### PR DESCRIPTION
Add arapuca_profile_set_allow_exec() to the C FFI so that consumers (e.g. go-arapuca) can opt into Landlock Execute on read paths.

Without this, Profile.allow_exec defaults to false and is unreachable from the C API. This breaks sandboxed execution of shebang scripts (Python, shell, etc.) because Landlock denies Execute on the interpreter binaries (/usr/bin/env, python3) resolved during execve — only the script file itself and the ELF interpreter (ld-linux) were granted Execute.
