### PR TITLE
cgroup: add CgroupPolicy for graceful degradation

### DIFF
--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -202,14 +202,14 @@ void arapuca_profile_set_max_open_files(struct arapuca_ArapucaProfile *profile, 
 /**
  * Enable/disable exec permission for sandboxed processes.
  *
- * When enabled, read paths gain the Landlock Execute access right,
- * allowing execve on any binary reachable through them. Write paths
- * also gain Execute (they receive full access). When disabled (the
- * default), only the target binary and the ELF interpreter are
+ * When enabled, read paths gain the Landlock `Execute` access right,
+ * allowing `execve` on any binary reachable through them. Write
+ * paths also gain Execute (they receive full access). When disabled
+ * (the default), only the target binary and the ELF interpreter are
  * executable.
  *
- * Scripts that use a shebang (e.g. #!/usr/bin/env python3) require
- * allow_exec = true because the kernel's script interpreter
+ * Scripts that use a shebang (e.g. `#!/usr/bin/env python3`) require
+ * `allow_exec = true` because the kernel's script interpreter
  * resolution needs Execute on the interpreter binary, not just the
  * script itself.
  *
@@ -217,6 +217,31 @@ void arapuca_profile_set_max_open_files(struct arapuca_ArapucaProfile *profile, 
  * `profile` must be a valid pointer.
  */
 void arapuca_profile_set_allow_exec(struct arapuca_ArapucaProfile *profile, bool enabled);
+
+/**
+ * Set cgroup enforcement policy.
+ *
+ * When `best_effort` is true, the sandbox uses whatever cgroup
+ * controllers are delegated and skips the rest with a warning.
+ * When false (default), missing cgroup controllers cause a hard failure.
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_cgroup_best_effort(struct arapuca_ArapucaProfile *profile,
+                                            bool best_effort);
+
+/**
+ * Set a hard CPU-time cap in seconds via RLIMIT_CPU.
+ *
+ * Kills the process with SIGXCPU after `seconds` of cumulative CPU
+ * time. Independent of `max_cpu_pct` (proportional scheduling).
+ * Set to 0 to disable (default).
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_cpu_timeout(struct arapuca_ArapucaProfile *profile, uint64_t seconds);
 
 /**
  * Enable/disable network namespace isolation.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -109,6 +109,7 @@ pub enum AuditEvent {
         memory_mb: u64,
         cpu_pct: u32,
         max_pids: u32,
+        cpu_timeout_secs: u64,
         max_file_size_mb: u64,
         max_open_files: u64,
         allow_exec: bool,
@@ -305,6 +306,7 @@ pub enum LayerDetail {
     Cgroup {
         path: String,
         swap_disabled: bool,
+        degraded: Vec<String>,
     },
     ProxyBridge {
         port: u16,

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -26,8 +26,23 @@ const CPU_PERIOD: i64 = 100_000; // microseconds
 /// Result of creating a cgroup directory.
 #[derive(Debug)]
 pub struct CgroupCreateResult {
-    pub path: PathBuf,
+    /// Cgroup directory path. `None` if no controllers were applied.
+    pub path: Option<PathBuf>,
     pub swap_disabled: bool,
+    pub memory_applied: bool,
+    pub pids_applied: bool,
+    pub cpu_applied: bool,
+    /// Controller names that were requested but not delegated.
+    pub degraded: Vec<String>,
+}
+
+/// Internal status from write_controller_files.
+struct ControllerWriteStatus {
+    swap_disabled: bool,
+    memory_applied: bool,
+    pids_applied: bool,
+    cpu_applied: bool,
+    degraded: Vec<String>,
 }
 
 /// Resource limits for a cgroup.
@@ -133,8 +148,9 @@ impl CgroupManager {
 
     /// Create a cgroup for the given task with the specified limits.
     ///
-    /// Returns the cgroup directory path and whether swap was disabled.
-    /// On failure, any partially created directory is cleaned up.
+    /// Returns per-controller status indicating which limits were
+    /// applied and which controllers were unavailable. On hard I/O
+    /// failure, the directory is cleaned up.
     pub fn create(
         &self,
         task_id: &str,
@@ -149,10 +165,24 @@ impl CgroupManager {
             .map_err(|e| Error::Cgroup(format!("mkdir {}: {e}", cg_path.display())))?;
 
         match self.write_controller_files(&cg_path, limits) {
-            Ok(swap_disabled) => Ok(CgroupCreateResult {
-                path: cg_path,
-                swap_disabled,
-            }),
+            Ok(status) => {
+                let any_applied =
+                    status.memory_applied || status.pids_applied || status.cpu_applied;
+                let path = if any_applied {
+                    Some(cg_path)
+                } else {
+                    let _ = fs::remove_dir(&cg_path);
+                    None
+                };
+                Ok(CgroupCreateResult {
+                    path,
+                    swap_disabled: status.swap_disabled,
+                    memory_applied: status.memory_applied,
+                    pids_applied: status.pids_applied,
+                    cpu_applied: status.cpu_applied,
+                    degraded: status.degraded,
+                })
+            }
             Err(e) => {
                 let _ = fs::remove_dir(&cg_path);
                 Err(e)
@@ -258,10 +288,24 @@ impl CgroupManager {
         usage
     }
 
-    /// Returns `Ok(true)` if all writes succeeded (swap disabled),
-    /// `Ok(false)` if swap.max write failed (memory limits still applied).
-    fn write_controller_files(&self, cg_path: &Path, limits: &CgroupLimits) -> crate::Result<bool> {
-        let mut swap_disabled = true;
+    /// Attempt to write each requested controller's limits.
+    ///
+    /// Continues past missing controllers (recording them in `degraded`)
+    /// so that available controllers are still applied. Hard I/O errors
+    /// (writing to a controller that IS available fails) still propagate.
+    fn write_controller_files(
+        &self,
+        cg_path: &Path,
+        limits: &CgroupLimits,
+    ) -> crate::Result<ControllerWriteStatus> {
+        let mut status = ControllerWriteStatus {
+            swap_disabled: true,
+            memory_applied: false,
+            pids_applied: false,
+            cpu_applied: false,
+            degraded: Vec::new(),
+        };
+
         if limits.memory_max_mb > 0 {
             if self.has_controller("memory") {
                 let mem_max = limits
@@ -273,12 +317,11 @@ impl CgroupManager {
                 write_cgroup_file(cg_path, "memory.high", &mem_high.to_string())?;
                 if let Err(e) = write_cgroup_file(cg_path, "memory.swap.max", "0") {
                     log::warn!("cgroup: memory.swap.max: {e} (continuing)");
-                    swap_disabled = false;
+                    status.swap_disabled = false;
                 }
+                status.memory_applied = true;
             } else {
-                return Err(Error::CgroupDegraded(
-                    "memory controller not delegated".into(),
-                ));
+                status.degraded.push("memory".into());
             }
         }
 
@@ -286,10 +329,9 @@ impl CgroupManager {
             if self.has_controller("pids") {
                 let effective_pids = limits.pids_max.saturating_add(limits.pids_overhead);
                 write_cgroup_file(cg_path, "pids.max", &effective_pids.to_string())?;
+                status.pids_applied = true;
             } else {
-                return Err(Error::CgroupDegraded(
-                    "pids controller not delegated".into(),
-                ));
+                status.degraded.push("pids".into());
             }
         }
 
@@ -298,12 +340,13 @@ impl CgroupManager {
                 let quota = i64::from(limits.cpu_max_pct) * CPU_PERIOD / 100;
                 let val = format!("{quota} {CPU_PERIOD}");
                 write_cgroup_file(cg_path, "cpu.max", &val)?;
+                status.cpu_applied = true;
             } else {
-                return Err(Error::CgroupDegraded("cpu controller not delegated".into()));
+                status.degraded.push("cpu".into());
             }
         }
 
-        Ok(swap_disabled)
+        Ok(status)
     }
 
     /// Clean up leftover cgroup directories from previous sessions.

--- a/src/env.rs
+++ b/src/env.rs
@@ -356,6 +356,12 @@ pub fn wrapper_env(profile: &crate::Profile) -> crate::Result<Vec<(String, Strin
             profile.max_open_files.to_string(),
         ));
     }
+    if profile.cpu_timeout_secs > 0 {
+        env.push((
+            "ARAPUCA_RLIMIT_CPU".into(),
+            profile.cpu_timeout_secs.to_string(),
+        ));
+    }
     // Always emit — never rely on absence encoding a default.
     // Linux::launch() calls env_clear() so ambient vars don't leak,
     // but defense-in-depth: explicit is better than implicit.

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,11 +21,6 @@ pub enum Error {
     #[error("cgroup: {0}")]
     Cgroup(String),
 
-    /// Cgroup controller not delegated (soft failure — caller decides
-    /// degradation policy).
-    #[error("cgroup controller not delegated: {0}")]
-    CgroupDegraded(String),
-
     /// Micro-VM operation failed.
     #[error("microvm: {0}")]
     MicroVm(String),

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -248,6 +248,50 @@ pub unsafe extern "C" fn arapuca_profile_set_allow_exec(
     }
 }
 
+/// Set cgroup enforcement policy.
+///
+/// When `best_effort` is true, the sandbox uses whatever cgroup
+/// controllers are delegated and skips the rest with a warning.
+/// When false (default), missing cgroup controllers cause a hard failure.
+///
+/// # Safety
+/// `profile` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_cgroup_best_effort(
+    profile: *mut ArapucaProfile,
+    best_effort: bool,
+) {
+    if let Some(profile) = unsafe { profile.as_mut() } {
+        if let Some(inner) = profile.inner.as_mut() {
+            inner.cgroup_policy = if best_effort {
+                crate::CgroupPolicy::BestEffort
+            } else {
+                crate::CgroupPolicy::Required
+            };
+        }
+    }
+}
+
+/// Set a hard CPU-time cap in seconds via RLIMIT_CPU.
+///
+/// Kills the process with SIGXCPU after `seconds` of cumulative CPU
+/// time. Independent of `max_cpu_pct` (proportional scheduling).
+/// Set to 0 to disable (default).
+///
+/// # Safety
+/// `profile` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_cpu_timeout(
+    profile: *mut ArapucaProfile,
+    seconds: u64,
+) {
+    if let Some(profile) = unsafe { profile.as_mut() } {
+        if let Some(inner) = profile.inner.as_mut() {
+            inner.cpu_timeout_secs = seconds;
+        }
+    }
+}
+
 /// Enable/disable network namespace isolation.
 ///
 /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use process::Process;
 pub use audit::sanitize_audit_string;
 pub use error::Error;
 pub use profile::{
-    Config, GuestFile, ImageSource, Isolation, MicroVmConfig, Profile, ResourceUsage,
+    CgroupPolicy, Config, GuestFile, ImageSource, Isolation, MicroVmConfig, Profile, ResourceUsage,
     SeccompProfile,
 };
 #[cfg(unix)]

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -25,7 +25,13 @@ use crate::audit::{
 };
 use crate::cgroup::{CgroupLimits, CgroupManager};
 use crate::platform::Sandbox;
-use crate::{Config, Error, process::Process};
+use crate::{CgroupPolicy, Config, Error, process::Process};
+
+const CGROUP_DELEGATE_HINT: &str = "\
+sudo mkdir -p /etc/systemd/system/user@.service.d && \
+sudo sh -c 'printf \"[Service]\\nDelegate=cpu cpuset memory pids\\n\" \
+> /etc/systemd/system/user@.service.d/delegate.conf' && \
+sudo systemctl daemon-reload";
 
 /// Linux sandbox implementation.
 pub struct Linux {
@@ -710,49 +716,91 @@ impl Sandbox for Linux {
             if limits.has_limits() {
                 match mgr.create(&cfg.task_id, &limits) {
                     Ok(result) => {
-                        if !result.swap_disabled {
-                            log::warn!("cgroup: memory.swap.max could not be set");
+                        if !result.degraded.is_empty() {
+                            match cfg.profile.cgroup_policy {
+                                CgroupPolicy::Required => {
+                                    if let Some(ref p) = result.path {
+                                        let _ = mgr.destroy(p);
+                                    }
+                                    return Err(Error::Cgroup(format!(
+                                        "resource limits requested but controllers \
+                                         not delegated: {} — fix with: {CGROUP_DELEGATE_HINT}",
+                                        result.degraded.join(", ")
+                                    )));
+                                }
+                                CgroupPolicy::BestEffort => {
+                                    let msg = if result.path.is_some() {
+                                        "enforcement is partial"
+                                    } else {
+                                        "no controllers available — enforcement is not active"
+                                    };
+                                    log::warn!(
+                                        "cgroup: controllers not delegated: {} — {msg}",
+                                        result.degraded.join(", ")
+                                    );
+                                }
+                            }
                         }
-                        if let Some(ref ctx) = audit_ctx {
-                            ctx.emit(AuditEvent::LayerApplied {
-                                timestamp: ctx.timestamp(),
-                                layer: SandboxLayer::Cgroup,
-                                detail: Some(LayerDetail::Cgroup {
-                                    path: sanitize_audit_string(&result.path.to_string_lossy()),
-                                    swap_disabled: result.swap_disabled,
-                                }),
-                            })?;
+                        if let Some(p) = result.path {
+                            if !result.swap_disabled {
+                                log::warn!("cgroup: memory.swap.max could not be set");
+                            }
+                            if let Some(ref ctx) = audit_ctx {
+                                ctx.emit(AuditEvent::LayerApplied {
+                                    timestamp: ctx.timestamp(),
+                                    layer: SandboxLayer::Cgroup,
+                                    detail: Some(LayerDetail::Cgroup {
+                                        path: sanitize_audit_string(&p.to_string_lossy()),
+                                        swap_disabled: result.swap_disabled,
+                                        degraded: result.degraded.clone(),
+                                    }),
+                                })?;
+                            }
+                            applied_layers.push(SandboxLayer::Cgroup);
+                            cgroup_path = Some(p);
+                        } else {
+                            if let Some(ref ctx) = audit_ctx {
+                                ctx.emit(AuditEvent::LayerSkipped {
+                                    timestamp: ctx.timestamp(),
+                                    layer: SandboxLayer::Cgroup,
+                                    reason: SkipReason::NotAvailable,
+                                })?;
+                            }
+                            skipped_layers.push(SandboxLayer::Cgroup);
                         }
-                        applied_layers.push(SandboxLayer::Cgroup);
-                        cgroup_path = Some(result.path);
                     }
                     Err(e) => {
-                        if limits.has_limits() {
-                            return Err(Error::Cgroup(format!(
-                                "resource limits requested but cgroup creation failed: {e}"
-                            )));
-                        }
-                        log::warn!(
-                            "cgroup creation failed: {e} (no limits configured, continuing)"
-                        );
-                        if let Some(ref ctx) = audit_ctx {
-                            ctx.emit(AuditEvent::LayerSkipped {
-                                timestamp: ctx.timestamp(),
-                                layer: SandboxLayer::Cgroup,
-                                reason: SkipReason::PartialFailure(sanitize_audit_string(
-                                    &format!("{e}"),
-                                )),
-                            })?;
-                        }
-                        skipped_layers.push(SandboxLayer::Cgroup);
+                        return Err(Error::Cgroup(format!("cgroup creation failed: {e}")));
                     }
                 }
             }
         } else if limits.has_limits() {
-            return Err(Error::Cgroup(format!(
-                "resource limits requested (memory={}MB, pids={}) but cgroups unavailable",
-                cfg.profile.max_memory_mb, cfg.profile.max_pids
-            )));
+            match cfg.profile.cgroup_policy {
+                CgroupPolicy::Required => {
+                    return Err(Error::Cgroup(format!(
+                        "resource limits requested (memory={}MB, cpu={}%, pids={}) \
+                         but cgroups unavailable — fix with: {CGROUP_DELEGATE_HINT}",
+                        cfg.profile.max_memory_mb, cfg.profile.max_cpu_pct, cfg.profile.max_pids
+                    )));
+                }
+                CgroupPolicy::BestEffort => {
+                    log::warn!(
+                        "cgroup: resource limits requested (memory={}MB, cpu={}%, pids={}) \
+                         but cgroups unavailable — limits will not be enforced",
+                        cfg.profile.max_memory_mb,
+                        cfg.profile.max_cpu_pct,
+                        cfg.profile.max_pids
+                    );
+                    if let Some(ref ctx) = audit_ctx {
+                        ctx.emit(AuditEvent::LayerSkipped {
+                            timestamp: ctx.timestamp(),
+                            layer: SandboxLayer::Cgroup,
+                            reason: SkipReason::NotAvailable,
+                        })?;
+                    }
+                    skipped_layers.push(SandboxLayer::Cgroup);
+                }
+            }
         }
 
         // ── Cgroup sync pipe ──────────────────────────────────────
@@ -943,6 +991,7 @@ impl Sandbox for Linux {
                 memory_mb: cfg.profile.max_memory_mb,
                 cpu_pct: cfg.profile.max_cpu_pct,
                 max_pids: cfg.profile.max_pids,
+                cpu_timeout_secs: cfg.profile.cpu_timeout_secs,
                 max_file_size_mb: cfg.profile.max_file_size_mb,
                 max_open_files: cfg.profile.max_open_files,
                 allow_exec: cfg.profile.allow_exec,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -93,6 +93,21 @@ impl SeccompProfile {
     }
 }
 
+/// Policy for cgroup resource limits when controllers aren't delegated.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum CgroupPolicy {
+    /// Hard-fail if cgroups are unavailable and resource limits are
+    /// requested. The sandbox refuses to launch.
+    #[default]
+    Required,
+    /// Log a warning and continue with whatever cgroup controllers
+    /// are delegated. Controllers that are unavailable are skipped.
+    /// Landlock, seccomp, and namespace isolation still apply.
+    /// Memory and PID limits require their respective cgroup
+    /// controllers and cannot be enforced without them.
+    BestEffort,
+}
+
 /// Filesystem and resource restrictions for a sandboxed process.
 #[derive(Debug, Clone, Default)]
 pub struct Profile {
@@ -111,6 +126,13 @@ pub struct Profile {
     /// Maximum number of processes (0 = no limit). Enforced via
     /// cgroups v2 `pids.max` on Linux.
     pub max_pids: u32,
+    /// Cgroup enforcement policy. Defaults to Required.
+    pub cgroup_policy: CgroupPolicy,
+    /// Hard CPU-time cap in seconds via RLIMIT_CPU (0 = no limit).
+    /// Kills the process with SIGXCPU after this many seconds of
+    /// cumulative CPU time (user + system). Independent of
+    /// `max_cpu_pct` (proportional scheduling via cgroup `cpu.max`).
+    pub cpu_timeout_secs: u64,
     /// Maximum file size in MB via RLIMIT_FSIZE (0 = no limit).
     pub max_file_size_mb: u64,
     /// Maximum open file descriptors via RLIMIT_NOFILE (0 = no limit).

--- a/src/rlimit.rs
+++ b/src/rlimit.rs
@@ -16,6 +16,8 @@
 
 use crate::{Error, Profile};
 
+const MAX_CPU_TIMEOUT_SECS: u64 = 30 * 24 * 3600;
+
 /// Apply resource limits from the profile to the current process.
 ///
 /// Sets RLIMIT_CORE=0 unconditionally (prevents core dumps from
@@ -36,6 +38,19 @@ use crate::{Error, Profile};
 #[must_use = "rlimit errors must be handled"]
 pub fn apply(profile: &Profile) -> crate::Result<()> {
     set_rlimit(libc::RLIMIT_CORE as _, 0, "RLIMIT_CORE")?;
+    if profile.cpu_timeout_secs > 0 {
+        if profile.cpu_timeout_secs > MAX_CPU_TIMEOUT_SECS {
+            return Err(Error::Rlimit(format!(
+                "cpu_timeout_secs {} exceeds maximum ({MAX_CPU_TIMEOUT_SECS})",
+                profile.cpu_timeout_secs
+            )));
+        }
+        set_rlimit(
+            libc::RLIMIT_CPU as _,
+            profile.cpu_timeout_secs,
+            "RLIMIT_CPU",
+        )?;
+    }
     if profile.max_file_size_mb > 0 {
         let bytes = profile
             .max_file_size_mb
@@ -67,6 +82,11 @@ pub fn apply_from_env() -> crate::Result<()> {
         set_rlimit(libc::RLIMIT_NPROC as _, v, "RLIMIT_NPROC")?;
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_CPU")? {
+        if v > MAX_CPU_TIMEOUT_SECS {
+            return Err(Error::Rlimit(format!(
+                "ARAPUCA_RLIMIT_CPU {v} exceeds maximum ({MAX_CPU_TIMEOUT_SECS})"
+            )));
+        }
         set_rlimit(libc::RLIMIT_CPU as _, v, "RLIMIT_CPU")?;
     }
     if let Some(v) = parse_env_u64("ARAPUCA_RLIMIT_FSIZE")? {
@@ -135,6 +155,16 @@ mod tests {
     fn zero_limits_are_skipped() {
         let profile = Profile::default();
         assert!(apply(&profile).is_ok());
+    }
+
+    #[test]
+    fn cpu_timeout_above_max_rejected() {
+        let profile = Profile {
+            cpu_timeout_secs: MAX_CPU_TIMEOUT_SECS + 1,
+            ..Default::default()
+        };
+        let err = apply(&profile).unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"));
     }
 
     #[test]


### PR DESCRIPTION
When cgroup controllers aren't delegated (common in SSH sessions), the sandbox previously hard-failed if resource limits were requested.

Add a CgroupPolicy enum (Required/BestEffort) to Profile. In BestEffort mode, the sandbox launches with Landlock+seccomp+netns but without cgroup limits, applying coarse RLIMIT circuit breakers (RLIMIT_AS at 8x memory, RLIMIT_CPU at 3600s) as a backstop. The Required mode error message now includes the exact systemd command to fix controller delegation.

Expose CgroupPolicy through the FFI via
arapuca_profile_set_cgroup_best_effort().