### PR TITLE
fix(windows): always engage AppContainer; make LPAC opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ arapuca run \
 | `--audit-network` | Emit network connection audit events (Linux) |
 | `--seccomp-debug` | Log blocked syscalls to stderr instead of killing (diagnostic) |
 | `--no-pid-ns` | Disable PID namespace isolation |
+| `--lpac` | Run as a Less Privileged AppContainer; may break binaries needing registry/DLL access outside the LPAC allowlist (Windows) |
 | `-t, --tty` | Allocate a PTY for interactive programs |
 
 ### Micro-VM (requires `microvm` feature)

--- a/include/arapuca.h
+++ b/include/arapuca.h
@@ -281,6 +281,20 @@ int32_t arapuca_profile_set_seccomp(struct arapuca_ArapucaProfile *profile,
 void arapuca_profile_set_pidns(struct arapuca_ArapucaProfile *profile, bool enabled);
 
 /**
+ * Enable/disable Windows LPAC (Less Privileged AppContainer).
+ *
+ * Off by default. AppContainer confinement is always engaged on
+ * Windows regardless of this setting; LPAC additionally strips the
+ * implicit "ALL APPLICATION PACKAGES" SID, which most non-Microsoft-
+ * signed binaries depend on for registry/DLL access and will fail to
+ * launch without. No effect on non-Windows platforms.
+ *
+ * # Safety
+ * `profile` must be a valid pointer.
+ */
+void arapuca_profile_set_lpac(struct arapuca_ArapucaProfile *profile, bool enabled);
+
+/**
  * Enable DNS query capture inside the network namespace.
  *
  * When enabled alongside netns, the bridge child intercepts DNS

--- a/src/bin/arapuca.rs
+++ b/src/bin/arapuca.rs
@@ -601,6 +601,7 @@ fn run_subcommand(args: &[String]) {
     let mut audit_network = false;
     let mut allow_proxy_env = false;
     let mut allow_keychain = false;
+    let mut lpac = false;
 
     // Find -- separator.
     let sep_pos = args.iter().position(|a| a == "--");
@@ -636,6 +637,11 @@ fn run_subcommand(args: &[String]) {
             eprintln!("                     SSL_CERT_FILE/CURL_CA_BUNDLE are not forwarded)");
             eprintln!("  --seccomp MODE     seccomp profile: strict (default) or baseline");
             eprintln!("  --no-pid-ns        disable PID namespace isolation");
+            eprintln!("  --lpac             run as a Less Privileged AppContainer (Windows only);");
+            eprintln!(
+                "                     may break binaries that need registry/DLL access outside"
+            );
+            eprintln!("                     the LPAC allowlist");
             eprintln!(
                 "  --allow-keychain   allow macOS Keychain access; sets HOME to your \
                  home dir (macOS only)"
@@ -827,6 +833,11 @@ fn run_subcommand(args: &[String]) {
             "--no-pid-ns" => {
                 no_pid_ns = true;
             }
+            "--lpac" => {
+                lpac = true;
+                #[cfg(not(windows))]
+                eprintln!("arapuca run: --lpac is Windows-only; ignored on this platform");
+            }
             "--audit-files" => {
                 audit_files = true;
             }
@@ -965,6 +976,7 @@ fn run_subcommand(args: &[String]) {
         use_netns,
         use_pidns: use_netns && !no_pid_ns,
         dns_capture: deny_network,
+        lpac,
         seccomp_profile,
         audit_file_access: audit_files,
         audit_network: audit_network || deny_network,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -366,6 +366,25 @@ pub unsafe extern "C" fn arapuca_profile_set_pidns(profile: *mut ArapucaProfile,
     }
 }
 
+/// Enable/disable Windows LPAC (Less Privileged AppContainer).
+///
+/// Off by default. AppContainer confinement is always engaged on
+/// Windows regardless of this setting; LPAC additionally strips the
+/// implicit "ALL APPLICATION PACKAGES" SID, which most non-Microsoft-
+/// signed binaries depend on for registry/DLL access and will fail to
+/// launch without. No effect on non-Windows platforms.
+///
+/// # Safety
+/// `profile` must be a valid pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arapuca_profile_set_lpac(profile: *mut ArapucaProfile, enabled: bool) {
+    if let Some(profile) = unsafe { profile.as_mut() } {
+        if let Some(inner) = profile.inner.as_mut() {
+            inner.lpac = enabled;
+        }
+    }
+}
+
 /// Enable DNS query capture inside the network namespace.
 ///
 /// When enabled alongside netns, the bridge child intercepts DNS

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -59,6 +59,15 @@ const PROC_THREAD_ATTRIBUTE_JOB_LIST: usize = 0x0002_000D;
 const PROC_THREAD_ATTRIBUTE_HANDLE_LIST: usize = 0x0002_0002;
 const PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY: usize = 0x0002_0007;
 const PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES: usize = 0x0002_0009;
+const PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY: usize = 0x0002_000F;
+
+// PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT: opt the child out
+// of the implicit "ALL APPLICATION PACKAGES" SID so it runs as a Less
+// Privileged AppContainer (LPAC). Without this, every AppContainer
+// process retains broad read/execute access to System32, Program
+// Files, and other locations the "ALL APPLICATION PACKAGES" group is
+// granted, defeating much of the intended confinement.
+const PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT: u32 = 0x1;
 
 // QWORD 1 of PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY.
 // ACG (1 << 36, prohibit dynamic code) is deliberately omitted: it
@@ -109,8 +118,13 @@ impl Sandbox for Windows {
             .collect();
         let inherit_handles = if handle_list.is_empty() { 0 } else { TRUE };
 
-        let use_appcontainer =
-            !cfg.profile.read_paths.is_empty() || !cfg.profile.write_paths.is_empty();
+        // Always engage AppContainer confinement, even with zero
+        // explicitly granted paths. AppContainer denies filesystem
+        // access by default; gating it on a non-empty grant list
+        // meant the common zero-path case silently fell through to
+        // the restricted-token-only fallback below, which provides
+        // NO filesystem read confinement at all.
+        let use_appcontainer = true;
 
         // ── AppContainer path: filesystem + network isolation ──
         let mut container_name_owned: Option<String> = None;
@@ -217,7 +231,17 @@ impl Sandbox for Windows {
         }
 
         // ── Build attribute list ──
-        let attr_count = if use_appcontainer { 4 } else { 3 };
+        // LPAC is opt-in (cfg.profile.lpac): AppContainer alone already
+        // denies filesystem access by default; LPAC additionally strips
+        // the "ALL APPLICATION PACKAGES" SID, which most non-Microsoft-
+        // signed binaries depend on for registry/DLL access.
+        let use_lpac = use_appcontainer && cfg.profile.lpac;
+        let attr_count = if use_appcontainer {
+            if use_lpac { 5 } else { 4 }
+        } else {
+            3
+        };
+        let mut lpac_policy: u32 = PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT;
         let job_raw = job_handle.as_raw_handle() as HANDLE;
         let policy_qword2 = if !cfg.profile.allow_exec {
             1u64 << 44 // PROCESS_CREATION_CHILD_PROCESS_RESTRICTED (ALWAYS_ON)
@@ -245,6 +269,11 @@ impl Sandbox for Windows {
             attr_list
                 .add_security_capabilities(&mut sec_caps)
                 .inspect_err(cleanup_full)?;
+            if use_lpac {
+                attr_list
+                    .add_all_app_packages_policy(&mut lpac_policy)
+                    .inspect_err(cleanup_full)?;
+            }
         }
 
         // ── Build STARTUPINFOEXW ──
@@ -701,6 +730,29 @@ impl AttributeList {
         if ret == 0 {
             return Err(Error::Process(format!(
                 "UpdateProcThreadAttribute(SECURITY_CAPABILITIES): {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Opt the child out of "ALL APPLICATION PACKAGES" (LPAC).
+    fn add_all_app_packages_policy(&mut self, policy: &mut u32) -> crate::Result<()> {
+        // SAFETY: policy is a valid u32 that outlives the attribute list.
+        let ret = unsafe {
+            UpdateProcThreadAttribute(
+                self.as_ptr(),
+                0,
+                PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY,
+                (policy as *mut u32).cast(),
+                std::mem::size_of::<u32>(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ret == 0 {
+            return Err(Error::Process(format!(
+                "UpdateProcThreadAttribute(ALL_APPLICATION_PACKAGES_POLICY): {}",
                 std::io::Error::last_os_error()
             )));
         }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -25,10 +25,7 @@ use windows_sys::Win32::Security::Authorization::{
     SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_W,
 };
 use windows_sys::Win32::Security::{
-    CreateRestrictedToken, CreateWellKnownSid, DISABLE_MAX_PRIVILEGE, SECURITY_CAPABILITIES,
-    SID_AND_ATTRIBUTES, SetTokenInformation, TOKEN_ACCESS_MASK, TOKEN_ADJUST_DEFAULT,
-    TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE, TOKEN_MANDATORY_LABEL, TOKEN_QUERY, TokenIntegrityLevel,
-    WinCapabilityInternetClientSid,
+    CreateWellKnownSid, SECURITY_CAPABILITIES, SID_AND_ATTRIBUTES, WinCapabilityInternetClientSid,
 };
 use windows_sys::Win32::System::Console::{
     GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
@@ -44,12 +41,10 @@ use windows_sys::Win32::System::JobObjects::{
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectBasicUIRestrictions,
     JobObjectCpuRateControlInformation, JobObjectExtendedLimitInformation, SetInformationJobObject,
 };
-use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 use windows_sys::Win32::System::Threading::{
-    CREATE_NO_WINDOW, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessW,
-    DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetCurrentProcess,
-    InitializeProcThreadAttributeList, OpenProcessToken, PROCESS_INFORMATION, ResumeThread,
-    STARTF_USESTDHANDLES, STARTUPINFOEXW, TerminateProcess, UpdateProcThreadAttribute,
+    CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT, CreateProcessW, DeleteProcThreadAttributeList,
+    EXTENDED_STARTUPINFO_PRESENT, GetCurrentProcess, InitializeProcThreadAttributeList,
+    PROCESS_INFORMATION, STARTF_USESTDHANDLES, STARTUPINFOEXW, UpdateProcThreadAttribute,
 };
 
 use crate::platform::Sandbox;
@@ -118,23 +113,26 @@ impl Sandbox for Windows {
             .collect();
         let inherit_handles = if handle_list.is_empty() { 0 } else { TRUE };
 
-        // Always engage AppContainer confinement, even with zero
-        // explicitly granted paths. AppContainer denies filesystem
-        // access by default; gating it on a non-empty grant list
-        // meant the common zero-path case silently fell through to
-        // the restricted-token-only fallback below, which provides
-        // NO filesystem read confinement at all.
-        let use_appcontainer = true;
-
         // ── AppContainer path: filesystem + network isolation ──
-        let mut container_name_owned: Option<String> = None;
+        //
+        // AppContainer confinement is always engaged, even with zero
+        // explicitly granted paths: it denies filesystem access by
+        // default, which is the load-bearing property. An earlier
+        // version of this code only engaged it when read_paths or
+        // write_paths was non-empty, so the common zero-path case
+        // silently fell through to a restricted-token-only fallback
+        // that provided NO filesystem read confinement at all. That
+        // fallback path has been removed (see git history) along with
+        // this always-true condition, so a future change can't
+        // silently reintroduce the same gap.
+        let container_name_owned: Option<String>;
         let mut saved_dacls: Vec<SavedDacl> = Vec::new();
-        let mut app_container_sid: Option<AppContainerSid> = None;
+        let app_container_sid: AppContainerSid;
         let mut net_sid_buf = vec![0u8; 68]; // MAX_SID_SIZE
         let mut capabilities: Vec<SID_AND_ATTRIBUTES> = Vec::new();
         let mut sec_caps: SECURITY_CAPABILITIES = unsafe { std::mem::zeroed() };
 
-        if use_appcontainer {
+        {
             let name = container_name(&cfg.task_id);
             let ac_sid = create_app_container(&name).inspect_err(cleanup_tmp)?;
 
@@ -150,7 +148,9 @@ impl Sandbox for Windows {
                         log::warn!("rollback DACL restore: {e}");
                     }
                 }
-                let _ = delete_app_container(cname);
+                if let Err(e) = delete_app_container(cname) {
+                    log::warn!("rollback AppContainer delete: {e}");
+                }
                 let _ = std::fs::remove_dir_all(&tmp_dir);
             };
 
@@ -227,7 +227,7 @@ impl Sandbox for Windows {
             }
 
             container_name_owned = Some(name);
-            app_container_sid = Some(ac_sid);
+            app_container_sid = ac_sid;
         }
 
         // ── Build attribute list ──
@@ -235,12 +235,8 @@ impl Sandbox for Windows {
         // denies filesystem access by default; LPAC additionally strips
         // the "ALL APPLICATION PACKAGES" SID, which most non-Microsoft-
         // signed binaries depend on for registry/DLL access.
-        let use_lpac = use_appcontainer && cfg.profile.lpac;
-        let attr_count = if use_appcontainer {
-            if use_lpac { 5 } else { 4 }
-        } else {
-            3
-        };
+        let use_lpac = cfg.profile.lpac;
+        let attr_count = if use_lpac { 5 } else { 4 };
         let mut lpac_policy: u32 = PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT;
         let job_raw = job_handle.as_raw_handle() as HANDLE;
         let policy_qword2 = if !cfg.profile.allow_exec {
@@ -265,15 +261,13 @@ impl Sandbox for Windows {
             .add_mitigation_policy(&mut policy)
             .inspect_err(cleanup_full)?;
 
-        if use_appcontainer {
+        attr_list
+            .add_security_capabilities(&mut sec_caps)
+            .inspect_err(cleanup_full)?;
+        if use_lpac {
             attr_list
-                .add_security_capabilities(&mut sec_caps)
+                .add_all_app_packages_policy(&mut lpac_policy)
                 .inspect_err(cleanup_full)?;
-            if use_lpac {
-                attr_list
-                    .add_all_app_packages_policy(&mut lpac_policy)
-                    .inspect_err(cleanup_full)?;
-            }
         }
 
         // ── Build STARTUPINFOEXW ──
@@ -289,84 +283,30 @@ impl Sandbox for Windows {
 
         let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
 
-        if use_appcontainer {
-            // AppContainer path: SECURITY_CAPABILITIES creates the lowbox
-            // token at spawn. No CREATE_SUSPENDED or token swap — swapping
-            // the token would destroy AppContainer isolation. Privilege
-            // stripping is not applied; AppContainer's deny-by-default
-            // access model renders most privileges inert.
-            let ret = unsafe {
-                CreateProcessW(
-                    std::ptr::null(),
-                    cmdline.as_mut_ptr(),
-                    std::ptr::null(),
-                    std::ptr::null(),
-                    inherit_handles,
-                    CREATE_NO_WINDOW | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
-                    env_block.as_ptr().cast(),
-                    work_dir.as_ref().map_or(std::ptr::null(), |v| v.as_ptr()),
-                    &raw mut si.StartupInfo,
-                    &mut pi,
-                )
-            };
-            drop(attr_list);
-            if ret == 0 {
-                let err = std::io::Error::last_os_error();
-                rollback_appcontainer(&saved_dacls, &container_name_owned, &tmp_dir);
-                return Err(Error::Process(format!("CreateProcessW: {err}")));
-            }
-        } else {
-            // Fallback path: CREATE_SUSPENDED + restricted token swap.
-            let restricted_token = create_restricted_token().inspect_err(cleanup_tmp)?;
-            let nt_set_info = resolve_nt_set_information_process().inspect_err(cleanup_tmp)?;
-
-            let ret = unsafe {
-                CreateProcessW(
-                    std::ptr::null(),
-                    cmdline.as_mut_ptr(),
-                    std::ptr::null(),
-                    std::ptr::null(),
-                    inherit_handles,
-                    CREATE_NO_WINDOW
-                        | CREATE_SUSPENDED
-                        | EXTENDED_STARTUPINFO_PRESENT
-                        | CREATE_UNICODE_ENVIRONMENT,
-                    env_block.as_ptr().cast(),
-                    work_dir.as_ref().map_or(std::ptr::null(), |v| v.as_ptr()),
-                    &raw mut si.StartupInfo,
-                    &mut pi,
-                )
-            };
-            drop(attr_list);
-            if ret == 0 {
-                let err = std::io::Error::last_os_error();
-                let _ = std::fs::remove_dir_all(&tmp_dir);
-                return Err(Error::Process(format!("CreateProcessW: {err}")));
-            }
-
-            if let Err(e) =
-                apply_restricted_token(nt_set_info, pi.hProcess, pi.hThread, &restricted_token)
-            {
-                unsafe {
-                    TerminateProcess(pi.hProcess, 1);
-                    CloseHandle(pi.hThread);
-                    CloseHandle(pi.hProcess);
-                }
-                let _ = std::fs::remove_dir_all(&tmp_dir);
-                return Err(e);
-            }
-
-            let resume_ret = unsafe { ResumeThread(pi.hThread) };
-            if resume_ret == u32::MAX {
-                let err = std::io::Error::last_os_error();
-                unsafe {
-                    TerminateProcess(pi.hProcess, 1);
-                    CloseHandle(pi.hThread);
-                    CloseHandle(pi.hProcess);
-                }
-                let _ = std::fs::remove_dir_all(&tmp_dir);
-                return Err(Error::Process(format!("ResumeThread: {err}")));
-            }
+        // SECURITY_CAPABILITIES creates the lowbox token at spawn. No
+        // CREATE_SUSPENDED or token swap — swapping the token would
+        // destroy AppContainer isolation. Privilege stripping is not
+        // applied; AppContainer's deny-by-default access model renders
+        // most privileges inert.
+        let ret = unsafe {
+            CreateProcessW(
+                std::ptr::null(),
+                cmdline.as_mut_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                inherit_handles,
+                CREATE_NO_WINDOW | EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                env_block.as_ptr().cast(),
+                work_dir.as_ref().map_or(std::ptr::null(), |v| v.as_ptr()),
+                &raw mut si.StartupInfo,
+                &mut pi,
+            )
+        };
+        drop(attr_list);
+        if ret == 0 {
+            let err = std::io::Error::last_os_error();
+            rollback_appcontainer(&saved_dacls, &container_name_owned, &tmp_dir);
+            return Err(Error::Process(format!("CreateProcessW: {err}")));
         }
 
         unsafe { CloseHandle(pi.hThread) };
@@ -443,168 +383,6 @@ fn duplicate_as_inheritable(handle: HANDLE) -> crate::Result<OwnedHandle> {
     }
     // SAFETY: dup is a valid handle from successful DuplicateHandle.
     Ok(unsafe { OwnedHandle::from_raw_handle(dup) })
-}
-
-// ─── Restricted token ──────────────────────────────────────────────
-
-fn create_restricted_token() -> crate::Result<OwnedHandle> {
-    let mut token: HANDLE = std::ptr::null_mut();
-    // SAFETY: GetCurrentProcess is always valid. token is a valid out pointer.
-    let ret = unsafe {
-        OpenProcessToken(
-            GetCurrentProcess(),
-            (TOKEN_DUPLICATE | TOKEN_QUERY | TOKEN_ADJUST_DEFAULT | TOKEN_ASSIGN_PRIMARY)
-                as TOKEN_ACCESS_MASK,
-            &mut token,
-        )
-    };
-    if ret == 0 {
-        return Err(Error::Process(format!(
-            "OpenProcessToken: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-    let token = unsafe { OwnedHandle::from_raw_handle(token) };
-
-    let mut restricted: HANDLE = std::ptr::null_mut();
-    // SAFETY: token is valid. DISABLE_MAX_PRIVILEGE strips all privileges.
-    // No deny-only SIDs or restricting SIDs for now — those require
-    // enumerating the token's groups which is complex. The privilege
-    // stripping + Low IL provide meaningful privilege reduction.
-    let ret = unsafe {
-        CreateRestrictedToken(
-            token.as_raw_handle() as HANDLE,
-            DISABLE_MAX_PRIVILEGE,
-            0,
-            std::ptr::null(),
-            0,
-            std::ptr::null(),
-            0,
-            std::ptr::null(),
-            &mut restricted,
-        )
-    };
-    if ret == 0 {
-        return Err(Error::Process(format!(
-            "CreateRestrictedToken: {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-    let restricted = unsafe { OwnedHandle::from_raw_handle(restricted) };
-
-    // Lower integrity to Low (S-1-16-4096).
-    set_token_integrity_low(&restricted)?;
-
-    Ok(restricted)
-}
-
-fn set_token_integrity_low(token: &OwnedHandle) -> crate::Result<()> {
-    // S-1-16-4096 (Low Mandatory Level)
-    #[repr(C)]
-    struct SidBuffer {
-        revision: u8,
-        sub_authority_count: u8,
-        identifier_authority: [u8; 6],
-        sub_authority: [u32; 1],
-    }
-
-    let low_sid = SidBuffer {
-        revision: 1,
-        sub_authority_count: 1,
-        identifier_authority: [0, 0, 0, 0, 0, 16], // SECURITY_MANDATORY_LABEL_AUTHORITY
-        sub_authority: [4096],                     // SECURITY_MANDATORY_LOW_RID
-    };
-
-    let label = TOKEN_MANDATORY_LABEL {
-        Label: windows_sys::Win32::Security::SID_AND_ATTRIBUTES {
-            Sid: (&raw const low_sid).cast::<std::ffi::c_void>() as *mut _,
-            Attributes: 0x00000020, // SE_GROUP_INTEGRITY
-        },
-    };
-
-    // SAFETY: token is valid, label is a valid TOKEN_MANDATORY_LABEL.
-    let ret = unsafe {
-        SetTokenInformation(
-            token.as_raw_handle() as HANDLE,
-            TokenIntegrityLevel,
-            (&raw const label).cast(),
-            std::mem::size_of::<TOKEN_MANDATORY_LABEL>() as u32,
-        )
-    };
-    if ret == 0 {
-        return Err(Error::Process(format!(
-            "SetTokenInformation(IntegrityLevel): {}",
-            std::io::Error::last_os_error()
-        )));
-    }
-    Ok(())
-}
-
-type NtSetInformationProcessFn = unsafe extern "system" fn(
-    process_handle: HANDLE,
-    process_information_class: u32,
-    process_information: *const std::ffi::c_void,
-    process_information_length: u32,
-) -> i32;
-
-fn resolve_nt_set_information_process() -> crate::Result<NtSetInformationProcessFn> {
-    let ntdll: Vec<u16> = "ntdll.dll\0".encode_utf16().collect();
-    let func_name = b"NtSetInformationProcess\0";
-
-    // SAFETY: ntdll.dll is always loaded in every Windows process.
-    let module = unsafe { GetModuleHandleW(ntdll.as_ptr()) };
-    if module.is_null() {
-        return Err(Error::Process("GetModuleHandleW(ntdll.dll) failed".into()));
-    }
-    // SAFETY: module is valid, func_name is null-terminated.
-    let proc = unsafe { GetProcAddress(module, func_name.as_ptr().cast()) };
-    let Some(proc) = proc else {
-        return Err(Error::Process(
-            "NtSetInformationProcess not found in ntdll.dll".into(),
-        ));
-    };
-    // SAFETY: proc is a valid function pointer from GetProcAddress.
-    Ok(unsafe {
-        std::mem::transmute::<unsafe extern "system" fn() -> isize, NtSetInformationProcessFn>(proc)
-    })
-}
-
-fn apply_restricted_token(
-    nt_set_info: NtSetInformationProcessFn,
-    process: HANDLE,
-    thread: HANDLE,
-    token: &OwnedHandle,
-) -> crate::Result<()> {
-    // ProcessAccessToken = 9
-    const PROCESS_ACCESS_TOKEN: u32 = 9;
-
-    #[repr(C)]
-    struct ProcessAccessTokenInfo {
-        token: HANDLE,
-        thread: HANDLE,
-    }
-
-    let info = ProcessAccessTokenInfo {
-        token: token.as_raw_handle() as HANDLE,
-        thread,
-    };
-
-    // SAFETY: process is a valid suspended process handle. token and
-    // thread are valid handles. The process has zero started threads.
-    let status = unsafe {
-        nt_set_info(
-            process,
-            PROCESS_ACCESS_TOKEN,
-            (&raw const info).cast(),
-            std::mem::size_of::<ProcessAccessTokenInfo>() as u32,
-        )
-    };
-    if status != 0 {
-        return Err(Error::Process(format!(
-            "NtSetInformationProcess(ProcessAccessToken): NTSTATUS 0x{status:08X}"
-        )));
-    }
-    Ok(())
 }
 
 // ─── Attribute list RAII wrapper ───────────────────────────────────
@@ -915,7 +693,9 @@ fn rollback_appcontainer(
         }
     }
     if let Some(name) = container_name {
-        let _ = delete_app_container(name);
+        if let Err(e) = delete_app_container(name) {
+            log::warn!("rollback AppContainer delete: {e}");
+        }
     }
     let _ = std::fs::remove_dir_all(tmp_dir);
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -125,7 +125,7 @@ impl Sandbox for Windows {
         // fallback path has been removed (see git history) along with
         // this always-true condition, so a future change can't
         // silently reintroduce the same gap.
-        let container_name_owned: Option<String>;
+        let container_name_owned: String;
         let mut saved_dacls: Vec<SavedDacl> = Vec::new();
         let app_container_sid: AppContainerSid;
         let mut net_sid_buf = vec![0u8; 68]; // MAX_SID_SIZE
@@ -226,7 +226,7 @@ impl Sandbox for Windows {
                 sec_caps.CapabilityCount = capabilities.len() as u32;
             }
 
-            container_name_owned = Some(name);
+            container_name_owned = name;
             app_container_sid = ac_sid;
         }
 
@@ -322,7 +322,7 @@ impl Sandbox for Windows {
             tmp_dir,
             waited: false,
             job_handle: Some(job_handle),
-            container_name: container_name_owned,
+            container_name: Some(container_name_owned),
             saved_dacls,
             audit_ctx: None,
             final_stats: None,
@@ -682,20 +682,14 @@ fn set_job_ui_restrictions(handle: &OwnedHandle) -> crate::Result<()> {
 
 // ─── Environment ───────────────────────────────────────────────────
 
-fn rollback_appcontainer(
-    saved_dacls: &[SavedDacl],
-    container_name: &Option<String>,
-    tmp_dir: &Path,
-) {
+fn rollback_appcontainer(saved_dacls: &[SavedDacl], container_name: &str, tmp_dir: &Path) {
     for sd in saved_dacls {
         if let Err(e) = restore_dacl(sd) {
             log::warn!("rollback DACL restore: {e}");
         }
     }
-    if let Some(name) = container_name {
-        if let Err(e) = delete_app_container(name) {
-            log::warn!("rollback AppContainer delete: {e}");
-        }
+    if let Err(e) = delete_app_container(container_name) {
+        log::warn!("rollback AppContainer delete: {e}");
     }
     let _ = std::fs::remove_dir_all(tmp_dir);
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -138,6 +138,18 @@ pub struct Profile {
     /// (`unshare --mount`). The `serde` Cargo feature is required for
     /// NDJSON parsing of audit events.
     pub dns_capture: bool,
+    /// Opt the child out of the implicit "ALL APPLICATION PACKAGES" SID
+    /// (Windows LPAC). Off by default: most non-Microsoft-signed binaries
+    /// (and even some Microsoft ones, e.g. certutil.exe/whoami.exe) depend
+    /// on registry keys/DLLs that were never ACL'd for the
+    /// "ALL RESTRICTED APPLICATION PACKAGES" SID and fail to launch at all
+    /// under LPAC (STATUS_DLL_INIT_FAILED/ACCESS_DENIED). AppContainer
+    /// alone (without this) already denies filesystem access by default,
+    /// which is the property that matters; LPAC only tightens read access
+    /// to System32/Program Files (Microsoft-signed, non-attacker-controlled)
+    /// and should stay opt-in until target binaries are verified compatible.
+    /// No effect on non-Windows platforms.
+    pub lpac: bool,
     /// Seccomp filter profile. Defaults to Strict.
     pub seccomp_profile: SeccompProfile,
     /// Audit file access via seccomp user notification.


### PR DESCRIPTION
## Summary

Two related fixes to the Windows sandbox backend, found while exercising real-world binaries under the jail on Windows Server 2022:

1. **AppContainer confinement was silently skipped with zero explicit grants.** `use_appcontainer` was only set when `read_paths`/`write_paths` was non-empty, so the common zero-path config fell through to the restricted-token-only path, which gives **no** filesystem read confinement at all. Fixed by always engaging AppContainer — it denies filesystem access by default, so this is safe (and strictly more confined) even with zero grants.

2. **LPAC was forced unconditionally**, via `PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT`. LPAC-token processes only get access to resources ACL'd for the narrow "ALL RESTRICTED APPLICATION PACKAGES" SID (S-1-15-2-2) — a mostly-Microsoft-curated allowlist. Live-tested: this broke launching `python.exe` and `curl.exe` with `STATUS_DLL_INIT_FAILED`, not just the binaries expected to need it. Fixed by adding `Profile.lpac` (bool, default `false`); `use_appcontainer` stays unconditional, only the `ALL_APPLICATION_PACKAGES_OPT_OUT` attribute is now gated on the new flag.

## Verification

- `cargo check --target x86_64-pc-windows-gnu` — clean, zero warnings.
- Live-tested on a real Windows Server 2022 host: with LPAC off, `python.exe`/`curl.exe` launch and run correctly inside the jail (previously both failed); `cmd.exe` unaffected either way.